### PR TITLE
Update copy of pricing tiers, update readme instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,13 +6,19 @@ This is the public website for RocketSim.
 
 From your terminal:
 
-1. Install dependencies
+1. Change directory to `docs`
+
+```sh
+cd docs
+```
+
+2. Install dependencies
 
 ```sh
 npm install
 ```
 
-2. Run dev server
+3. Run dev server
 
 ```sh
 npm run dev

--- a/docs/src/content/sections/pricing.md
+++ b/docs/src/content/sections/pricing.md
@@ -3,109 +3,110 @@ title: "Choose a pricing plan best suited <em>for you</em>"
 
 plans:
   - enable: true
-    title: Trial
-    description: Keen to try it out first? Sign up for a free two weeks trial.
-    price_prefix: ""
-    color: "#1d1d1f"
-    features:
-      - enable: true
-        included: true
-        feature: Pro access to RocketSim.
-      - enable: true
-        included: true
-        feature: Team build insights.
-      - enable: true
-        included: true
-        feature: User management.
-      - enable: true
-        included: true
-        feature: License management.
-    price:
-      yearly:
-        amount: FREE
-        period: ""
-    cta:
-      enable: true
-      label: Sign up for a free trial
-      site: teams
-      link: "/signup/trial"
-  - enable: true
-    title: Individual
-    description: Perfect for solo developers.
+    title: Free
+    description: Explore how our 30+ Xcode Simulator features can increase your productivity
     price_prefix: "€"
     color: "#1d1d1f"
     features:
       - enable: true
-        included: true
-        feature: Pro access to RocketSim.
+        included: false
+        feature: Pro access to RocketSim
       - enable: true
         included: false
-        feature: Team build insights.
+        feature: Team build insights
       - enable: true
         included: false
-        feature: User management.
+        feature: User management
       - enable: true
         included: false
-        feature: License management.
+        feature: License management
     price:
       yearly:
-        amount: 50
-        period: per year
+        amount: 0
+        period: per month
     cta:
       enable: true
       label: Download now
       site: custom
-      link: "https://apps.apple.com/app/apple-store/id1504940162?pt=117264678&ct=website-header&mt=8"
-      class: "plausible-event-name=App+Store+Install"
+      link: "https://apps.apple.com/app/apple-store/id1504940162?pt=117264678&ct=pricing-table-free&mt=8"
+      class: "plausible-event-name=App+Store+Install+Free"
   - enable: true
-    title: Teams
-    description: Perfect for teams with multiple developers.
+    title: Personal
+    description: Ideal for solo developers—enjoy every Pro feature with an in-app purchase
     price_prefix: "€"
     color: "#1d1d1f"
     features:
       - enable: true
         included: true
-        feature: Pro access to RocketSim.
+        feature: Pro access to RocketSim
       - enable: true
-        included: true
-        feature: Team build insights.
+        included: false
+        feature: Team build insights
       - enable: true
-        included: true
-        feature: User management.
+        included: false
+        feature: User management
       - enable: true
-        included: true
-        feature: License management.
+        included: false
+        feature: License management
     price:
       yearly:
-        amount: 120
-        period: "per year"
+        amount: 5
+        period: per month
     cta:
       enable: true
-      label: Subscribe
+      label: Download now
       site: custom
-      link: "/contact" # TODO: link to Stripe
-  - enable: false
-    title: Enterprise
-    description: For larger enterprises with complex requirements.
-    price_prefix: ""
+      link: "https://apps.apple.com/app/apple-store/id1504940162?pt=117264678&ct=pricing-table-personal&mt=8"
+      class: "plausible-event-name=App+Store+Install+Personal"
+  - enable: true
+    title: Teams
+    description: Perfect for teams with multiple developers
+    price_prefix: "€"
     color: "#1d1d1f"
     features:
       - enable: true
         included: true
-        feature: "Everything in Teams, and:"
+        feature: Pro access to RocketSim
       - enable: true
         included: true
-        feature: SAML based SSO.
+        feature: Team build insights
       - enable: true
         included: true
-        feature: Distribution outside of the App Store.
+        feature: User management
       - enable: true
         included: true
-        feature: Group based user management.
+        feature: License management
     price:
       yearly:
-        amount: COMING SOON
-        period: ""
+        amount: 10
+        period: "per month"
+    cta:
+      enable: true
+      label: Start 14-day Trial
+      site: custom
+      link: "/signup/trial"
+  - enable: false
+    title: Enterprise
+    description: For larger enterprises with complex requirements
+    price_prefix: "€"
+    color: "#1d1d1f"
+    features:
+      - enable: true
+        included: true
+        feature: "Everything in Teams"
+      - enable: true
+        included: true
+        feature: SAML based SSO
+      - enable: true
+        included: true
+        feature: Distribution outside of the App Store
+      - enable: true
+        included: true
+        feature: Group based user management
+    price:
+      yearly:
+        amount: "15"
+        period: "per month"
     cta:
       enable: true
       label: Contact sales

--- a/docs/src/layouts/partials/PricingSection.astro
+++ b/docs/src/layouts/partials/PricingSection.astro
@@ -94,7 +94,7 @@ const teamsUrl =
                                         height="24"
                                         viewBox="0 0 24 24"
                                         fill="none"
-                                        class="text-text-light w-full max-w-6 aspect-square "
+                                        class="text-light w-full max-w-6 aspect-square "
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
                                         <g opacity="0.4">

--- a/docs/src/layouts/partials/PricingSection.astro
+++ b/docs/src/layouts/partials/PricingSection.astro
@@ -94,7 +94,7 @@ const teamsUrl =
                                         height="24"
                                         viewBox="0 0 24 24"
                                         fill="none"
-                                        class="text-primary w-full max-w-6 aspect-square "
+                                        class="text-text-light w-full max-w-6 aspect-square "
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
                                         <g opacity="0.4">
@@ -144,11 +144,7 @@ const teamsUrl =
                               : `${plan.cta.site === "teams" ? teamsUrl : ""}${plan.cta.link}`
                           }
                           class:list={[
-                            "btn inline-block self-start mt-14 text-center rounded-full",
-                            {
-                              "btn btn-primary": isEvenIndex,
-                            },
-                            { "btn btn-secondary": !isEvenIndex },
+                            "btn inline-block self-start mt-14 text-center rounded-full btn-primary",
                             plan.cta.class,
                           ]}
                         >


### PR DESCRIPTION
<img width="1320" height="1426" alt="CleanShot 2025-07-16 at 11 30 44@2x" src="https://github.com/user-attachments/assets/2bbae810-51dc-45c7-9a73-124bdaf8e390" />

- [x] Updated the copy
- [x] Added a Free plan instead of trial plan
- [x] Change CTA of teams to start trial
- [x] Changed pricing to monthly
- [x] Removed all trialing dots to make things cleaner
- [x] Introduced a price of €15 per month for enterprise, I feel like this is a great price to use and makes our pricing grow equally (€0, €5, €10, €15)
- [x] All CTAs have the same primary color to indicate it's clickable UX. They're all equally "heavy/important", depending on the user 
- [x] Changed the color of the X SVG to be white, so the blue checkmark stands out more
- [x] Updated the readme with instructions on changing directory before using `npm` (I always run into the same, haha)