### PR TITLE
Fix broken docs links

### DIFF
--- a/docs/src/components/starlight/Footer.astro
+++ b/docs/src/components/starlight/Footer.astro
@@ -11,7 +11,7 @@ import { Icon } from "@astrojs/starlight/components";
 
 <div class="footer-links">
   <a href="/"><Icon name="rocket" /> Home</a>
-  <a href="/team-licenses"><Icon name="star" /> For teams</a>
+  <a href="/team-insights"><Icon name="star" /> For teams</a>
   <a
     href="https://apps.apple.com/app/apple-store/id1504940162?pt=117264678&ct=doc-footer&mt=8"
     ><Icon name="apple" /> Mac App Store</a

--- a/docs/src/content/docs/docs/features/capturing/simulator-camera-support.md
+++ b/docs/src/content/docs/docs/features/capturing/simulator-camera-support.md
@@ -25,7 +25,7 @@ Camera simulation is available from the Capture side window tab:
 
    The side window in its state after camera permissions have been granted.
 
-4. Integrate RocketSim Connect following the in-app instructions. For more info, see [Introduction & Setup](../rocketsim-connect/introduction-and-setup)
+4. Integrate RocketSim Connect following the in-app instructions. For more info, see [Introduction & Setup](/docs/features/rocketsim-connect/introduction-and-setup)
 5. Start running your app
 
 ## Troubleshooting

--- a/docs/src/content/docs/docs/features/rocketsim-connect/network-traffic-monitoring.md
+++ b/docs/src/content/docs/docs/features/rocketsim-connect/network-traffic-monitoring.md
@@ -15,7 +15,7 @@ RocketSim Connect’s dynamic library gets loaded at runtime and swizzles URLSes
 
 ## How do I get started?
 
-Follow the instructions for RocketSim Connect as described [here](./introduction-and-setup).
+Follow the instructions for RocketSim Connect as described [here](/docs/features/rocketsim-connect/introduction-and-setup).
 
 ## Do I need to set up a proxy or certificates?
 


### PR DESCRIPTION
Astro handles relative links differently in the production build vs dev build