### PR TITLE
Add Open Graph image to docs pages

### DIFF
--- a/docs/src/components/starlight/Head.astro
+++ b/docs/src/components/starlight/Head.astro
@@ -5,6 +5,9 @@
  */
 import Default from "@astrojs/starlight/components/Head.astro";
 import PlausibleAnalytics from "@/components/PlausibleAnalytics.astro";
+import config from "@/config/config.json";
+
+const ogImage = `${config.site.base_url}${config.metadata.meta_image}`;
 ---
 
 <Default {...Astro.props}><slot /></Default>
@@ -23,15 +26,10 @@ import PlausibleAnalytics from "@/components/PlausibleAnalytics.astro";
 <meta name="author" content="RocketSim" />
 
 <!-- Open Graph image for social sharing -->
-<meta
-  property="og:image"
-  content="https://www.rocketsim.app/og-banner-rocketsim.jpg"
-/>
-<meta name="twitter:card" content="summary_large_image" />
-<meta
-  name="twitter:image"
-  content="https://www.rocketsim.app/og-banner-rocketsim.jpg"
-/>
+<meta property="og:site_name" content="RocketSim" />
+<meta property="og:image" content={ogImage} />
+<meta property="twitter:card" content="summary_large_image" />
+<meta property="twitter:image" content={ogImage} />
 <meta name="twitter:site" content="@rocketsim_app" />
 
 <PlausibleAnalytics />


### PR DESCRIPTION
## Summary
- Adds `og:image` and `twitter:image` meta tags to all Starlight docs pages
- Reuses the existing site OG banner (`/og-banner-rocketsim.jpg`) for consistency
- Adds `twitter:card` and `twitter:site` meta tags for large image previews

Note: `og:site_name` is already provided by Starlight's default Head component, so it is not duplicated here.

## Changes
- Modified `docs/src/components/starlight/Head.astro`

## Test plan
- [ ] Verify `npm run build` passes
- [ ] View page source on a docs page and confirm og:image tag is present
- [ ] Test social sharing preview with https://www.opengraph.xyz/