### PR TITLE
Rename /team-insights to /for-teams

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
   base: config.site.base_path,
   trailingSlash: config.site.trailing_slash ? "always" : "never",
   redirects: {
+    "/team-insights": "/for-teams",
     "/docs/features/rocketsim-connect/introduction-and-setup":
       "/docs/getting-started/setting-up-rocketsim-connect",
     "/docs/features/rocketsim-connect/network-traffic-monitoring":

--- a/docs/src/config/menu.json
+++ b/docs/src/config/menu.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "For Teams",
-      "url": "/team-insights"
+      "url": "/for-teams"
     },
     {
       "name": "Pricing",
@@ -34,7 +34,7 @@
     },
     {
       "name": "For Teams",
-      "url": "/team-insights"
+      "url": "/for-teams"
     },
     {
       "name": "Pricing",

--- a/docs/src/layouts/partials/CallToAction.astro
+++ b/docs/src/layouts/partials/CallToAction.astro
@@ -11,7 +11,7 @@ const sectionData = (await getEntry(
 )) as CollectionEntry<"ctaSectionCollection">;
 const { enable, title, description, image, call_to_actions } = sectionData.data;
 
-const isTeamPage = Astro.url.pathname === "/team-insights";
+const isTeamPage = Astro.url.pathname === "/for-teams";
 const isPricingPage = Astro.url.pathname === "/pricing";
 
 const callToActions = isTeamPage

--- a/docs/src/layouts/partials/Header.astro
+++ b/docs/src/layouts/partials/Header.astro
@@ -195,7 +195,7 @@ const { pathname } = Astro.url;
           {
             navigation_buttons
               .filter((button) =>
-                pathname !== "/team-insights" && button.label === "Login"
+                pathname !== "/for-teams" && button.label === "Login"
                   ? false
                   : true,
               )

--- a/docs/src/pages/for-teams.astro
+++ b/docs/src/pages/for-teams.astro
@@ -28,7 +28,7 @@ const {
 const seo = {
   title: meta_title || `${title} - RocketSim`,
   description,
-  canonical: `${base_url}/team-insights`,
+  canonical: `${base_url}/for-teams`,
 };
 
 const structuredData = {
@@ -37,7 +37,7 @@ const structuredData = {
     name: "RocketSim for Teams",
     description: description,
     image: `${base_url}/images/rocketsim-app-icon.png`,
-    url: `${base_url}/team-insights`,
+    url: `${base_url}/for-teams`,
   },
 };
 ---


### PR DESCRIPTION
## Summary
- Renames the `team-insights.astro` page to `for-teams.astro` to match the "For Teams" navigation label
- Adds a redirect from `/team-insights` → `/for-teams` in `astro.config.ts`
- Updates all internal references in menu config, Header, and CallToAction partials

## Test plan
- [ ] Verify `/for-teams` loads correctly
- [ ] Verify `/team-insights` redirects to `/for-teams`
- [ ] Verify navigation links point to `/for-teams`

🤖 Generated with [Claude Code](https://claude.com/claude-code)