### PR TITLE
Fix privacy policy email address typo

### DIFF
--- a/docs/src/pages/privacy.astro
+++ b/docs/src/pages/privacy.astro
@@ -191,7 +191,7 @@ const seo = {
         </p>
         <p><strong>Personal data:</strong></p>
         <ul>
-          <li>email address</li>
+          <li>Email address</li>
           <li>Full name</li>
           <li>Device hardware ID (hashed)</li>
           <li>Device name (ie. Macbook of John Doe)</li>
@@ -255,7 +255,7 @@ const seo = {
         <p>For this purpose, we process the following personal data:</p>
         <ul>
           <li>Full name</li>
-          <li>email address</li>
+          <li>Email address</li>
         </ul>
         <p><strong>Legal basis:</strong></p>
         <ul>
@@ -278,7 +278,7 @@ const seo = {
         <p>For this purpose, we process the following personal data:</p>
         <ul>
           <li>Full name</li>
-          <li>email address</li>
+          <li>Email address</li>
         </ul>
         <p><strong>Legal basis:</strong></p>
         <ul>
@@ -293,7 +293,7 @@ const seo = {
         <p><strong>Purpose:</strong> Inform of new RocketSim features</p>
         <p><strong>Personal data:</strong></p>
         <ul>
-          <li>email address</li>
+          <li>Email address</li>
         </ul>
         <p><strong>Legal basis:</strong></p>
         <ul>


### PR DESCRIPTION
## Summary
- replace the malformed `E-mailaddress` entries in the privacy policy with `email address`
- keep the PR scoped to the privacy policy copy fix only

## Test plan
- [x] `cd docs && npm run lint`
- [x] `cd docs && npm run format:check`
- [x] `cd docs && npm run typecheck`
- [x] `cd docs && npm run build`
- [x] `cd docs && npm run knip`