### PR TITLE
fix: emit trailing-slash URLs to prevent "Page with redirect" in GSC

### DIFF
--- a/docs/src/config/config.json
+++ b/docs/src/config/config.json
@@ -3,7 +3,7 @@
     "base_url": "https://www.rocketsim.app",
     "teams_base_url": "https://teams.rocketsim.app",
     "base_path": "/",
-    "trailing_slash": false,
+    "trailing_slash": true,
     "title": "Build Apps Faster - RocketSim",
     "logo": "/images/rocketsim-logo.svg",
     "logo_width": "120",

--- a/docs/src/layouts/components/SEO.astro
+++ b/docs/src/layouts/components/SEO.astro
@@ -33,8 +33,12 @@ const {
   twitterSite = "@rocketsim_app",
 } = Astro.props;
 
-// Build canonical URL
-const canonicalUrl = canonical || Astro.url.href;
+// Build canonical URL (normalize to trailing slash when the site is configured for it)
+const rawCanonicalUrl = canonical || Astro.url.href;
+const canonicalUrl =
+  config.site.trailing_slash && !rawCanonicalUrl.endsWith("/")
+    ? `${rawCanonicalUrl}/`
+    : rawCanonicalUrl;
 
 // Use provided description or fall back to default meta description
 const metaDescription = description || config.metadata.meta_description;


### PR DESCRIPTION
## Summary

- Flip `trailing_slash` to `true` in `docs/src/config/config.json`. GH Pages hard-redirects `/path → /path/` for every directory-format page, so Astro's non-slash sitemap, canonicals, and internal links were all triggering 301s. That's why Search Console was flagging all 60 sitemap entries as "Page with redirect" and only indexing 11.
- Normalize caller-supplied canonical strings in `docs/src/layouts/components/SEO.astro`. 13 marketing/blog pages (homepage, features, pricing, for-teams, student, claim-offer, terms, privacy, thank-you, signup/trial/thank-you, blog posts) pass a hard-coded `canonical: \`${base_url}/slug\`` that doesn't read the flag. Without this, the canonical tag on `/features/index.html` would still point to `/features` even after flipping the flag, preserving the mismatch.

## Impact

- Sitemap: all 69 URLs now end with `/` (was: 0).
- Canonicals: homepage, all marketing pages, blog posts, feature subpages, docs, and the `/team-insights → /for-teams/` redirect HTML all emit trailing-slash canonicals. `og:url` and `twitter:url` follow since they derive from the same value.
- External backlinks to non-slash URLs will still get a GH Pages 301 → slash URL. That's expected and no longer affects our own sitemap/canonicals.

## Test plan

- [x] `npm run build` — 70 pages built, no errors.
- [x] `dist/sitemap-0.xml` inspected — 69 URLs, 0 missing trailing slash.
- [x] Canonicals verified on `/`, `/features/`, `/features/accessibility/`, `/pricing/`, `/for-teams/`, `/student/`, `/claim-offer/`, `/terms/`, `/privacy/`, `/thank-you/`, `/signup/trial/thank-you/`, `/blog/…/`, `/docs/features/app-actions/location-simulation/` — all trailing-slashed.
- [x] `/team-insights` redirect HTML points to `/for-teams/`.
- [x] `npm run lint` — clean.
- [x] `npm run format:check` — clean.
- [x] `npm run typecheck` — 0 errors, 0 warnings (1 pre-existing hint in `Intercom.astro`, unrelated).
- [ ] After deploy: URL Inspection on a previously-redirecting URL in Search Console should report indexable (no redirect); then Request Indexing and resubmit the sitemap. Re-crawl typically takes days to weeks — monitor the Page Indexing report over 1–2 weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)