### PR TITLE
Gate Intercom launcher behind intercom_preview localStorage flag

### DIFF
--- a/docs/src/layouts/components/Intercom.astro
+++ b/docs/src/layouts/components/Intercom.astro
@@ -1,41 +1,46 @@
 <script is:inline>
-  window.intercomSettings = {
-    api_base: "https://api-iam.intercom.io",
-    app_id: "wbadhzkf",
-  };
-</script>
-<script is:inline>
-  (function () {
-    var w = window;
-    var ic = w.Intercom;
-    if (typeof ic === "function") {
-      ic("reattach_activator");
-      ic("update", w.intercomSettings);
-    } else {
-      var d = document;
-      var i = function () {
-        i.c(arguments);
-      };
-      i.q = [];
-      i.c = function (args) {
-        i.q.push(args);
-      };
-      w.Intercom = i;
-      var l = function () {
-        var s = d.createElement("script");
-        s.type = "text/javascript";
-        s.async = true;
-        s.src = "https://widget.intercom.io/widget/wbadhzkf";
-        var x = d.getElementsByTagName("script")[0];
-        x.parentNode.insertBefore(s, x);
-      };
-      if (document.readyState === "complete") {
-        l();
-      } else if (w.attachEvent) {
-        w.attachEvent("onload", l);
+  // Gated on a localStorage flag so we can dogfood Intercom in production
+  // without exposing the Messenger to all visitors. Set
+  // `localStorage.setItem("intercom_preview", "true")` in the browser to opt
+  // in. Matches the gate on teams.rocketsim.app so the cross-subdomain cookie
+  // handoff only kicks in for opted-in visitors.
+  if (localStorage.getItem("intercom_preview") === "true") {
+    window.intercomSettings = {
+      api_base: "https://api-iam.intercom.io",
+      app_id: "wbadhzkf",
+    };
+    (function () {
+      var w = window;
+      var ic = w.Intercom;
+      if (typeof ic === "function") {
+        ic("reattach_activator");
+        ic("update", w.intercomSettings);
       } else {
-        w.addEventListener("load", l, false);
+        var d = document;
+        var i = function () {
+          i.c(arguments);
+        };
+        i.q = [];
+        i.c = function (args) {
+          i.q.push(args);
+        };
+        w.Intercom = i;
+        var l = function () {
+          var s = d.createElement("script");
+          s.type = "text/javascript";
+          s.async = true;
+          s.src = "https://widget.intercom.io/widget/wbadhzkf";
+          var x = d.getElementsByTagName("script")[0];
+          x.parentNode.insertBefore(s, x);
+        };
+        if (document.readyState === "complete") {
+          l();
+        } else if (w.attachEvent) {
+          w.attachEvent("onload", l);
+        } else {
+          w.addEventListener("load", l, false);
+        }
       }
-    }
-  })();
+    })();
+  }
 </script>

--- a/docs/src/layouts/components/Intercom.astro
+++ b/docs/src/layouts/components/Intercom.astro
@@ -1,9 +1,7 @@
 <script is:inline>
-  var isPreview = localStorage.getItem("intercom_preview") === "true";
   window.intercomSettings = {
     api_base: "https://api-iam.intercom.io",
     app_id: "wbadhzkf",
-    hide_default_launcher: !isPreview,
   };
 </script>
 <script is:inline>


### PR DESCRIPTION
## Summary

- Wraps the entire Intercom bootstrap in `src/layouts/components/Intercom.astro` behind a `intercom_preview` localStorage check — replacing the previous `hide_default_launcher`-only gate so non-preview visitors don't load the widget at all.
- Paired with the same gate on the dashboard (`teams.rocketsim.app`) so we can dogfood the cross-subdomain identified handoff in production without exposing Messenger to every visitor.
- Opt in per browser: `localStorage.setItem("intercom_preview", "true")`. Remove the item to opt out. Once we're happy with the flow, a follow-up PR will drop the gate on both sides.

## Paired change

Dashboard: https://github.com/AvdLee/LicenseKit/pull/670 — adds the verified-identity boot on `teams.rocketsim.app`, gated on the same flag.

## Identified session lifetime

The cross-subdomain handoff is carried by Intercom's own cookies on `.rocketsim.app`. Defaults:

| Cookie | Purpose | Default lifetime |
|---|---|---|
| `intercom-session-<app_id>` | Marks the visitor as having an active identified session — this anonymous boot reads it to surface the identified user | **~7 days, rolling (refreshes on activity)** |
| `intercom-id-<app_id>` | Visitor / contact ID | ~9 months |
| `intercom-device-id-<app_id>` | Device ID | ~9 months |

Practically this means:

- Dashboard today → public site within ~7 days of dashboard activity: still recognized as the identified user.
- Dashboard today → public site 8+ days later with no dashboard activity in between: the session cookie has expired and the public site treats them as anonymous again. Intercom's backend still links them to the same contact record via the 9-month visitor ID (so agents see prior history), but Identity Verification is no longer live in Messenger.

## Test plan

- [ ] In production, open `rocketsim.app` in a clean browser and confirm **no Intercom script loads** (no requests to `widget.intercom.io`).
- [ ] Run `localStorage.setItem("intercom_preview", "true")` in DevTools, reload, and confirm the Messenger launcher appears.
- [ ] With the preview flag also set on `teams.rocketsim.app`, log in there, then return to `rocketsim.app` and confirm the visitor is recognized as the identified user (not a fresh anonymous lead).
- [ ] `localStorage.removeItem("intercom_preview")`, reload, confirm Intercom disappears again.
- [ ] `npm run lint && npm run format:check && npm run typecheck && npm run build && npm run knip` — all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)