### PR TITLE
Add docs CTAs, sticky install banner, and analytics tracking

### DIFF
--- a/docs/src/components/starlight/DocsCTA.astro
+++ b/docs/src/components/starlight/DocsCTA.astro
@@ -1,0 +1,52 @@
+---
+interface Props {
+  title: string;
+  description: string;
+  primary: { label: string; href: string; event: string };
+  secondary?: { label: string; href: string; event: string };
+  compact?: boolean;
+  placement: "inline" | "bottom";
+}
+
+const {
+  title,
+  description,
+  primary,
+  secondary,
+  compact = false,
+  placement,
+} = Astro.props;
+---
+
+<section
+  class={`docs-cta ${compact ? "docs-cta--compact" : ""}`}
+  data-docs-cta
+  data-placement={placement}
+>
+  <div class="docs-cta__content">
+    <h2 class="docs-cta__title">{title}</h2>
+    <p class="docs-cta__description">{description}</p>
+  </div>
+  <div class="docs-cta__actions">
+    <a
+      class="sl-link-button primary docs-cta__button"
+      href={primary.href}
+      data-analytics-event={primary.event}
+      data-docs-cta-click
+    >
+      {primary.label}
+    </a>
+    {
+      secondary && (
+        <a
+          class="sl-link-button minimal docs-cta__button docs-cta__button--secondary"
+          href={secondary.href}
+          data-analytics-event={secondary.event}
+          data-docs-cta-click
+        >
+          {secondary.label}
+        </a>
+      )
+    }
+  </div>
+</section>

--- a/docs/src/components/starlight/DocsInstallBanner.astro
+++ b/docs/src/components/starlight/DocsInstallBanner.astro
@@ -1,0 +1,19 @@
+---
+
+---
+
+<aside class="docs-install-banner" data-docs-install-banner hidden>
+  <p class="docs-install-banner__text">Supercharge the iOS Simulator</p>
+  <a
+    href="https://apps.apple.com/app/apple-store/id1504940162?pt=117264678&ct=docs-sticky-banner&mt=8"
+    class="docs-install-banner__cta"
+    data-analytics-event="Docs Banner Click">Download Free</a
+  >
+  <button
+    type="button"
+    class="docs-install-banner__dismiss"
+    aria-label="Dismiss install banner"
+  >
+    ×
+  </button>
+</aside>

--- a/docs/src/components/starlight/Footer.astro
+++ b/docs/src/components/starlight/Footer.astro
@@ -5,9 +5,56 @@
  */
 import Default from "@astrojs/starlight/components/Footer.astro";
 import { Icon } from "@astrojs/starlight/components";
+import DocsCTA from "./DocsCTA.astro";
+import DocsInstallBanner from "./DocsInstallBanner.astro";
+import docsEngagementScript from "@/scripts/docs-engagement.ts?url";
+
+const pageId = Astro.locals.starlightRoute.id;
+const isDocsContentPage = pageId !== "404";
 ---
 
 <Default {...Astro.props}><slot /></Default>
+
+{
+  isDocsContentPage && (
+    <>
+      <div data-docs-cta-templates hidden>
+        <DocsCTA
+          placement="inline"
+          compact={true}
+          title="Save time while debugging iOS apps"
+          description="RocketSim adds powerful simulator tools directly to your workflow."
+          primary={{
+            label: "Download RocketSim",
+            href: "https://apps.apple.com/app/apple-store/id1504940162?pt=117264678&ct=docs-inline-cta&mt=8",
+            event: "Docs CTA Click - Inline Primary",
+          }}
+          secondary={{
+            label: "View Pricing",
+            href: "/pricing",
+            event: "Docs CTA Click - Inline Secondary",
+          }}
+        />
+        <DocsCTA
+          placement="bottom"
+          title="Save time while debugging iOS apps"
+          description="RocketSim adds powerful simulator tools directly to your workflow."
+          primary={{
+            label: "Download RocketSim",
+            href: "https://apps.apple.com/app/apple-store/id1504940162?pt=117264678&ct=docs-bottom-cta&mt=8",
+            event: "Docs CTA Click - Bottom Primary",
+          }}
+          secondary={{
+            label: "View Pricing",
+            href: "/pricing",
+            event: "Docs CTA Click - Bottom Secondary",
+          }}
+        />
+      </div>
+      <DocsInstallBanner />
+    </>
+  )
+}
 
 <div class="footer-links">
   <a href="/"><Icon name="rocket" /> Home</a>
@@ -18,3 +65,5 @@ import { Icon } from "@astrojs/starlight/components";
   >
   <a href="mailto:support@rocketsim.app"><Icon name="email" /> Contact us</a>
 </div>
+
+{isDocsContentPage && <script type="module" src={docsEngagementScript} />}

--- a/docs/src/scripts/docs-engagement.ts
+++ b/docs/src/scripts/docs-engagement.ts
@@ -1,0 +1,89 @@
+declare global {
+  interface Window {
+    plausible?: (
+      eventName: string,
+      options?: { props?: Record<string, string> },
+    ) => void;
+  }
+}
+
+const trackDocsEvent = (eventName: string, props?: Record<string, string>) => {
+  if (typeof window !== "undefined" && typeof window.plausible === "function") {
+    window.plausible(eventName, props ? { props } : undefined);
+  }
+};
+
+const initializeDocsEngagement = () => {
+  const content = document.querySelector("article .sl-markdown-content");
+  const templateRoot = document.querySelector("[data-docs-cta-templates]");
+
+  if (content && templateRoot) {
+    const [inlineTemplate, bottomTemplate] =
+      templateRoot.querySelectorAll("[data-docs-cta]");
+
+    if (inlineTemplate && !content.querySelector('[data-placement="inline"]')) {
+      const majorSections = content.querySelectorAll(
+        ":scope > h2, :scope > section",
+      );
+      const inlineCta = inlineTemplate.cloneNode(true) as HTMLElement;
+      inlineCta.removeAttribute("hidden");
+
+      const firstMajorSection = majorSections[0];
+      if (firstMajorSection?.nextSibling) {
+        firstMajorSection.parentNode?.insertBefore(
+          inlineCta,
+          firstMajorSection.nextSibling,
+        );
+      } else {
+        content.appendChild(inlineCta);
+      }
+      trackDocsEvent("Docs CTA Impression", { placement: "inline" });
+    }
+
+    if (bottomTemplate && !content.querySelector('[data-placement="bottom"]')) {
+      const bottomCta = bottomTemplate.cloneNode(true) as HTMLElement;
+      bottomCta.removeAttribute("hidden");
+      content.appendChild(bottomCta);
+      trackDocsEvent("Docs CTA Impression", { placement: "bottom" });
+    }
+  }
+
+  document.querySelectorAll("[data-docs-cta-click]").forEach((ctaLink) => {
+    ctaLink.addEventListener("click", () => {
+      const eventName = ctaLink.getAttribute("data-analytics-event");
+      if (eventName) trackDocsEvent(eventName);
+    });
+  });
+
+  const storageKey = "rocketsim_docs_banner_dismissed";
+  const banner = document.querySelector(
+    "[data-docs-install-banner]",
+  ) as HTMLElement | null;
+  if (!banner) return;
+
+  if (localStorage.getItem(storageKey) === "1") return;
+  banner.hidden = false;
+  trackDocsEvent("Docs Banner Shown");
+
+  const dismissButton = banner.querySelector(".docs-install-banner__dismiss");
+  dismissButton?.addEventListener("click", () => {
+    banner.hidden = true;
+    localStorage.setItem(storageKey, "1");
+    trackDocsEvent("Docs Banner Dismissed");
+  });
+
+  const bannerCta = banner.querySelector(".docs-install-banner__cta");
+  bannerCta?.addEventListener("click", () =>
+    trackDocsEvent("Docs Banner Click"),
+  );
+};
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initializeDocsEngagement, {
+    once: true,
+  });
+} else {
+  initializeDocsEngagement();
+}
+
+export {};

--- a/docs/src/styles/starlight-custom.css
+++ b/docs/src/styles/starlight-custom.css
@@ -464,3 +464,126 @@ footer.footer {
 .social-icons a:hover {
   color: var(--sl-color-accent);
 }
+
+/* ==========================================================================
+   Docs Conversion Components
+   ========================================================================== */
+
+.docs-cta {
+  margin: 2rem 0;
+  padding: 1.25rem;
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 0.9rem;
+  background: color-mix(
+    in srgb,
+    var(--sl-color-accent) 8%,
+    var(--sl-color-black)
+  );
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+:root[data-theme="light"] .docs-cta {
+  background: color-mix(
+    in srgb,
+    var(--sl-color-accent) 9%,
+    var(--sl-color-black)
+  );
+}
+
+.docs-cta__title {
+  margin: 0;
+  font-size: 1.2rem;
+  color: var(--sl-color-white);
+}
+
+.docs-cta__description {
+  margin: 0.35rem 0 0;
+  color: var(--sl-color-gray-2);
+}
+
+.docs-cta__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.docs-cta__button--secondary {
+  border: 1px solid var(--sl-color-gray-4);
+}
+
+.docs-cta--compact {
+  padding: 1rem;
+}
+
+.docs-install-banner {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--sl-color-gray-4);
+  background: color-mix(in srgb, var(--sl-color-gray-6) 92%, black);
+  color: var(--sl-color-gray-1);
+  padding: 0.45rem 0.45rem 0.45rem 0.9rem;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.24);
+  max-width: calc(100vw - 1.5rem);
+}
+
+.docs-install-banner__text {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.docs-install-banner__cta {
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  background: var(--sl-color-accent);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+
+.docs-install-banner__dismiss {
+  border: 0;
+  background: transparent;
+  color: var(--sl-color-gray-2);
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.docs-install-banner__dismiss:hover,
+.docs-install-banner__dismiss:focus-visible,
+.docs-install-banner__cta:focus-visible,
+.docs-cta__button:focus-visible {
+  outline: 2px solid var(--sl-color-accent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 50rem) {
+  .docs-cta {
+    margin: 1.5rem 0;
+  }
+
+  .docs-install-banner {
+    left: 0.75rem;
+    right: 0.75rem;
+    bottom: 0.75rem;
+    border-radius: 0.9rem;
+    justify-content: space-between;
+  }
+
+  .docs-install-banner__text {
+    font-size: 0.82rem;
+  }
+}


### PR DESCRIPTION
### Motivation
- Increase install conversions from docs traffic with low-risk, additive UX patterns while preserving the existing design system and performance.
- Provide lightweight instrumentation to measure CTA impressions, clicks, and banner interactions using the existing Plausible integration when available.

### Description
- Added a reusable `DocsCTA` Astro component supporting `title`, `description`, `primary`, optional `secondary`, a `compact` variant, responsive layout, accessible focus states, and data attributes for analytics hooks.
- Added a dismissible, mobile-friendly `DocsInstallBanner` component that persists dismissal in `localStorage` and is dark-mode compatible.
- Integrated automatic placement by rendering hidden CTA templates and the banner from `src/components/starlight/Footer.astro` and injecting them into docs pages via a small client script `src/scripts/docs-engagement.ts` (inserts a compact CTA after the first major content section and a full CTA at the bottom) without modifying MD/MDX sources.
- Instrumented events to use the existing Plausible helper when available, tracking `Docs CTA Impression` (with `placement`), CTA clicks (per-CTA event names), `Docs Banner Shown`, `Docs Banner Dismissed`, and `Docs Banner Click`.
- Added scoped styling in `src/styles/starlight-custom.css` to match the Starlight design tokens and provide accessible focus outlines and responsive behavior.
- Files changed / components added / integration points: modified `src/components/starlight/Footer.astro` and `src/styles/starlight-custom.css`, added `src/components/starlight/DocsCTA.astro`, `src/components/starlight/DocsInstallBanner.astro`, and `src/scripts/docs-engagement.ts`, and wired the client module into the docs footer to run only on docs content pages.

### Testing
- Ran `cd docs && npm run lint` and lint passed successfully.
- Ran `cd docs && npm run format:check` (Prettier) and formatting passed successfully after adjustments.
- Ran `cd docs && npm run typecheck` and type checks passed (client script compiled as a module and exported an empty export to satisfy module scope).
- Ran `cd docs && npm run knip` and it completed successfully.
- Ran `cd docs && npm run build` which completed client and static build steps locally but the full build failed in this environment due to an external network fetch error in `src/pages/blog/[slug].astro` (`ENETUNREACH`), unrelated to the CTA/banner changes; the docs-specific changes themselves did not trigger errors.

TODO / Recommendations
- Optionally align CTA event naming with existing `plausible-event-name=...` taxonomy for easier dashboard grouping.
- Consider excluding the docs homepage from the automatic insertions if overlapping homepage CTAs are undesirable (see `src/components/starlight/PageTitle.astro`).
- Monitor metrics after rollout and A/B test messaging or placement if desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a12e17ab8e08327beedec5acc55403b)