### PR TITLE
Sharpen homepage above-the-fold copy and CTA hierarchy

### DIFF
--- a/docs/src/old/components/Header.astro
+++ b/docs/src/old/components/Header.astro
@@ -5,12 +5,9 @@ import appIcon from "../../assets/rocketsim-app-icon.png";
 
 interface Props {
   title: string;
-  logo: ImageMetadata;
-  logoAlt: string;
-  scrollText?: string;
 }
 
-const { title, logo, logoAlt, scrollText } = Astro.props;
+const { title } = Astro.props;
 ---
 
 <style>
@@ -33,11 +30,6 @@ const { title, logo, logoAlt, scrollText } = Astro.props;
   }
 
   h1 {
-    display: inline-flex;
-    margin: 0 0 1rem;
-  }
-
-  h2 {
     margin: 0 0 0.5rem;
 
     font-size: 2rem;
@@ -46,19 +38,8 @@ const { title, logo, logoAlt, scrollText } = Astro.props;
     letter-spacing: -0.006rem;
   }
 
-  a {
-    display: inline-flex;
-  }
-
   p {
     margin: 0 0 1rem;
-  }
-
-  .hero__rocketsim {
-    &:focus-visible {
-      outline: 0.125rem solid var(--ring);
-      border-radius: 0.25rem;
-    }
   }
 
   .hero__logo {
@@ -83,16 +64,10 @@ const { title, logo, logoAlt, scrollText } = Astro.props;
 <header>
   <div class="deprecated-grid hero">
     <div class="hero__content">
-      <h1>
-        <a href="/" aria-label="RocketSim" class="hero__rocketsim"
-          ><Image src={logo} alt={logoAlt} height="48" /></a
-        >
-      </h1>
-      <h2>{title}</h2>
+      <h1>{title}</h1>
       <p>
         <slot />
       </p>
-      <p>{scrollText}</p>
     </div>
     <div class="hero__logo">
       <Image

--- a/docs/src/old/components/Navigation.astro
+++ b/docs/src/old/components/Navigation.astro
@@ -5,9 +5,10 @@ import appIcon from "../../assets/rocketsim-app-icon.png";
 
 interface Props {
   showLogin?: boolean;
+  microcopy?: string;
 }
 
-const { showLogin = false } = Astro.props;
+const { showLogin = false, microcopy } = Astro.props;
 ---
 
 <style>
@@ -91,6 +92,7 @@ const { showLogin = false } = Astro.props;
       <ul>
         <slot />
       </ul>
+      {microcopy && <p class="navigation__microcopy">{microcopy}</p>}
     </nav>
     <div class="navigation__right-column">
       {

--- a/docs/src/old/components/Navigation.astro
+++ b/docs/src/old/components/Navigation.astro
@@ -22,10 +22,12 @@ const { showLogin = false, microcopy } = Astro.props;
     box-sizing: content-box;
   }
 
-  nav {
+  .navigation__primary {
     @media (min-width: 800px) {
       display: flex;
-      align-items: center;
+      flex-direction: column;
+      align-items: flex-start;
+      justify-content: center;
       grid-column: 1 / -2;
     }
   }
@@ -48,6 +50,10 @@ const { showLogin = false, microcopy } = Astro.props;
     font-size: 0.75rem;
     color: #888;
     text-align: center;
+
+    @media (min-width: 800px) {
+      text-align: left;
+    }
   }
 
   .navigation__right-column {
@@ -88,12 +94,14 @@ const { showLogin = false, microcopy } = Astro.props;
 
 <div class:list={["navigation-wrapper"]} id="navigation-menu">
   <div class="navigation deprecated-grid">
-    <nav aria-label="Hero navigation">
-      <ul>
-        <slot />
-      </ul>
+    <div class="navigation__primary">
+      <nav aria-label="Hero navigation">
+        <ul>
+          <slot />
+        </ul>
+      </nav>
       {microcopy && <p class="navigation__microcopy">{microcopy}</p>}
-    </nav>
+    </div>
     <div class="navigation__right-column">
       {
         showLogin ? (

--- a/docs/src/pages/for-teams.astro
+++ b/docs/src/pages/for-teams.astro
@@ -15,8 +15,6 @@ import TeamTestimonial from "../old/components/TeamTestimonial.astro";
 import CallToAction from "@/partials/CallToAction.astro";
 import TrustedBrands from "@/partials/TrustedBrands.astro";
 
-import logoImage from "../assets/rocketsim-insights-logo.svg";
-
 const pageIndex = await getEntry("team-insights", "-index");
 if (!pageIndex) return null;
 const { title, meta_title, description } = pageIndex.data;
@@ -43,12 +41,7 @@ const structuredData = {
 ---
 
 <Base seo={seo} structuredData={structuredData}>
-  <Header
-    title="Make your whole team Build Apps Faster"
-    logo={logoImage}
-    logoAlt='Written logo spelling: "RocketSim for Teams"'
-    scrollText="Scroll down to explore all features ↓"
-  >
+  <Header title="Make your whole team Build Apps Faster">
     Connect your team using the same license key and gather team insights like
     p75 build duration, machine benchmarks, and more.
   </Header>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -16,8 +16,6 @@ import SocialMediaMentions from "../old/components/SocialMediaMentions.astro";
 import SubscribeToNewsletter from "../old/components/SubscribeToNewsletter.astro";
 import SupportAndFeedback from "../old/components/SupportAndFeedback.astro";
 
-import logoImage from "../assets/rocketsim-logo.svg";
-
 const {
   site: { base_url, title: siteTitle },
   metadata: { meta_description },
@@ -34,16 +32,14 @@ const seo = {
 <Base seo={seo} structuredData={{ type: "static" }}>
   <Notification />
   <Header
-    title="Build, test, and automate iOS apps faster in the Simulator"
-    logo={logoImage}
-    logoAlt='Written logo spelling: "RocketSim"'
-    scrollText="Scroll down to explore all features ↓"
+    title="The iOS Simulator companion for developers and AI coding agents."
   >
-    RocketSim gives iOS developers and AI coding agents a faster way to <strong
-      >inspect, test, record, and debug apps</strong
-    > in the Simulator without leaving their workflow.
+    RocketSim lets you <strong>inspect, test, and debug</strong> your app in the Simulator
+    — without breaking your flow in Xcode, Codex, or Cursor.
   </Header>
-  <Navigation>
+  <Navigation
+    microcopy="Get started for free, no signup. Works with Xcode 16+."
+  >
     <NavigationLink
       href="https://apps.apple.com/app/apple-store/id1504940162?pt=117264678&ct=website-header&mt=8"
       className="plausible-event-name=App+Store+Install plausible-event-surface=landing plausible-event-placement=landing-hero plausible-event-format=button"
@@ -52,13 +48,8 @@ const seo = {
       target="_blank"
       rel="noopener"
     >
-      Download now
+      Free download
     </NavigationLink>
-    <NavigationLink
-      href="/team-insights"
-      className="plausible-event-name=CTA:+Homepage+Hero+-+For+Teams"
-      >For Teams &rarr;</NavigationLink
-    >
     <NavigationLink
       href="/features"
       className="plausible-event-name=CTA:+Homepage+Hero+-+Features"

--- a/docs/src/pages/privacy.astro
+++ b/docs/src/pages/privacy.astro
@@ -7,8 +7,6 @@ import Header from "../old/components/Header.astro";
 import Navigation from "../old/components/Navigation.astro";
 import NavigationLink from "../old/components/NavigationLink.astro";
 
-import logoImage from "../assets/rocketsim-logo.svg";
-
 const pageIndex = await getEntry("privacy", "-index");
 if (!pageIndex) return null;
 const { title, meta_title, description } = pageIndex.data;
@@ -58,11 +56,7 @@ const seo = {
 </style>
 
 <Base seo={seo}>
-  <Header
-    title="RocketSim Privacy statement"
-    logo={logoImage}
-    logoAlt='Written logo spelling: "RocketSim"'
-  >
+  <Header title="RocketSim Privacy statement">
     Your privacy is important to us. This Privacy statement explains how
     RocketSim collects, uses, and protects your personal information.
   </Header>

--- a/docs/src/pages/terms.astro
+++ b/docs/src/pages/terms.astro
@@ -7,8 +7,6 @@ import Header from "../old/components/Header.astro";
 import Navigation from "../old/components/Navigation.astro";
 import NavigationLink from "../old/components/NavigationLink.astro";
 
-import logoImage from "../assets/rocketsim-logo.svg";
-
 const pageIndex = await getEntry("terms", "-index");
 if (!pageIndex) return null;
 const { title, meta_title, description } = pageIndex.data;
@@ -118,11 +116,7 @@ const seo = {
 </style>
 
 <Base seo={seo}>
-  <Header
-    title="RocketSim Terms and Conditions"
-    logo={logoImage}
-    logoAlt='Written logo spelling: "RocketSim"'
-  >
+  <Header title="RocketSim Terms and Conditions">
     Welcome to RocketSim! These Terms and Conditions govern your use of
     RocketSim, a developer tool designed to enhance app development experiences.
     By accessing or using RocketSim, you agree to these Terms. Please read them


### PR DESCRIPTION
## Summary

PR 1 of 2 applying [page-cro](https://github.com/AvdLee/RocketSimApp/blob/master/docs/.agents/skills/page-cro/SKILL.md) + [marketing-psychology](https://github.com/AvdLee/RocketSimApp/blob/master/docs/.agents/skills/marketing-psychology/SKILL.md) to the homepage above-the-fold. Copy-only — no layout changes, no new components. The social-proof restructure ships in PR 2.

### What changes above the fold

| Slot | Before | After |
|---|---|---|
| H1 | Script wordmark *"RocketSim"* (visual logo, already in nav) | **The iOS Simulator companion for developers and AI coding agents.** |
| Visual H2 / paragraph subhead | "Build, test, and automate iOS apps faster in the Simulator" + 4-verb subhead | (H1 above) + "RocketSim lets you **inspect, test, and debug** your app in the Simulator — without breaking your flow in Xcode, Codex, or Cursor." |
| Primary CTA | Download now | **Free download** (Zero-Price Effect) |
| Hero nav links | "For Teams →" + "Explore features →" | "Explore features →" only (Hick's Law) |
| Microcopy above the CTAs | "Scroll down to explore all features ↓" | _removed_ |
| Microcopy below the CTAs | _none_ | "Get started for free, no signup. Works with Xcode 16+." |

### Mental models applied

- **Curse of Knowledge**: H1 now names the audience and what the product *is*, not what it *does* in 4 verbs.
- **Zero-Price Effect**: primary CTA leads with "Free".
- **Hick's Law / Paradox of Choice**: one primary CTA + one secondary instead of three hero links.
- **Liking / Similarity Bias**: subhead names the actual editors the audience uses (Xcode, Codex, Cursor).

### Files

- ` + "`docs/src/old/components/Header.astro`" + ` — drop ` + "`logo`" + ` / ` + "`logoAlt`" + ` / ` + "`scrollText`" + ` props, render ` + "`title`" + ` as a real ` + "`<h1>`" + `.
- ` + "`docs/src/old/components/Navigation.astro`" + ` — new optional ` + "`microcopy`" + ` prop, renders the existing (previously orphan) ` + "`.navigation__microcopy`" + ` class.
- ` + "`docs/src/pages/index.astro`" + ` — all the homepage copy + CTA changes.
- ` + "`docs/src/pages/for-teams.astro`" + `, ` + "`docs/src/pages/terms.astro`" + `, ` + "`docs/src/pages/privacy.astro`" + ` — drop the now-removed ` + "`logo`" + ` / ` + "`logoAlt`" + ` / ` + "`scrollText`" + ` props to keep the Header signature consistent. Copy on these pages is unchanged.

App Store install tracking (Plausible event names, UTM-rewrite script, ` + "`rel=\"noopener\"`" + `) is untouched.

## Test plan

- [ ] Homepage hero reads top-to-bottom: H1 → bolded subhead → ` + "`Free download`" + ` + ` + "`Explore features →`" + ` → microcopy.
- [ ] No script wordmark, no "Scroll down…" line, no "For Teams →" in the homepage hero nav.
- [ ] ` + "`/for-teams`" + `, ` + "`/terms`" + `, ` + "`/privacy`" + ` render correctly with the new title-only Header (no wordmark, no scroll line).
- [ ] ` + "`Free download`" + ` button still fires the ` + "`App+Store+Install`" + ` Plausible event and the UTM-rewriting script still rewrites ` + "`#js-header-app-store-button`" + ` on load.
- [ ] CI quality gate: ` + "`npm run lint && npm run format:check && npm run typecheck && npm run build`" + ` all pass.

## Out of scope (PR 2)

- Restyle ` + "`AppStore.astro`" + ` into a slim authority strip with honest numbers (★4.8 · Apple Featured · 25K+ developers · 250+ teams).
- Add the ` + "`TrustedBrands`" + ` logo strip to the homepage with an optional homepage-specific title.

PR 2 will target this branch so both can be tested locally in one go.