### PR TITLE
Restructure homepage social-proof stack and polish the above-the-fold

### DIFF
--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -185,6 +185,33 @@ const { seo, structuredData } = Astro.props;
         onScroll(); // Check scroll position on page load
       };
 
+      // Hide the top-nav wordmark while the hero wordmark is in view.
+      // Avoids duplicating the brand at the top of the page; the nav
+      // wordmark fades in once the hero scrolls out of view.
+      let shyNavObserver: IntersectionObserver | null = null;
+      const shyNavLogoInit = () => {
+        if (shyNavObserver) {
+          shyNavObserver.disconnect();
+          shyNavObserver = null;
+        }
+        const navBrand = document.querySelector(".navbar-brand");
+        if (!navBrand) return;
+        const heroWordmark = document.getElementById("hero-wordmark");
+        if (!heroWordmark) {
+          navBrand.classList.remove("is-shy");
+          return;
+        }
+        shyNavObserver = new IntersectionObserver(
+          (entries) => {
+            for (const entry of entries) {
+              navBrand.classList.toggle("is-shy", entry.isIntersecting);
+            }
+          },
+          { rootMargin: "-80px 0px 0px 0px", threshold: 0 },
+        );
+        shyNavObserver.observe(heroWordmark);
+      };
+
       // AOS init
       import AOS from "aos";
       import "aos/dist/aos.css";
@@ -206,6 +233,7 @@ const { seo, structuredData } = Astro.props;
 
       document.addEventListener("astro:page-load", () => {
         stickyNavInit();
+        shyNavLogoInit();
         aosInit();
       });
 

--- a/docs/src/layouts/partials/TrustedBrands.astro
+++ b/docs/src/layouts/partials/TrustedBrands.astro
@@ -4,12 +4,19 @@ import { markdownify } from "@/lib/utils/textConverter";
 import type { CollectionEntry } from "astro:content";
 import { getEntry } from "astro:content";
 
+interface Props {
+  title?: string;
+}
+
+const { title: titleOverride } = Astro.props;
+
 const sectionData = (await getEntry(
   "trustedBrandsSectionCollection",
   "trusted-brands",
 )) as CollectionEntry<"trustedBrandsSectionCollection">;
 
-const { enable, title, list } = sectionData.data;
+const { enable, title: defaultTitle, list } = sectionData.data;
+const title = titleOverride ?? defaultTitle;
 ---
 
 <style>

--- a/docs/src/old/components/AppStore.astro
+++ b/docs/src/old/components/AppStore.astro
@@ -49,6 +49,7 @@ const appStoreHref =
 
     @media (min-width: 800px) {
       font-size: 1rem;
+      text-align: left;
     }
   }
 
@@ -107,10 +108,6 @@ const appStoreHref =
     </a>
   </div>
   <p class="authority-strip__copy">
-    <strong>★4.8 on the App Store</strong>
-    <span class="authority-strip__divider" aria-hidden="true">·</span>
-    Apple Featured: Essential Apps for Developers
-    <span class="authority-strip__divider" aria-hidden="true">·</span>
     <strong>25,000+ developers</strong>
     <span class="authority-strip__divider" aria-hidden="true">·</span>
     <strong>250+ teams</strong>

--- a/docs/src/old/components/AppStore.astro
+++ b/docs/src/old/components/AppStore.astro
@@ -3,65 +3,116 @@ import { Image } from "astro:assets";
 
 import appStoreReview from "../../assets/app-store-rating.jpg";
 import appStoreFeatured from "../../assets/app-store-featured.jpg";
+
+const appStoreHref =
+  "https://apps.apple.com/app/apple-store/id1504940162?pt=117264678&ct=Landing%20Page%20or%20Form%20-%208653523&mt=8";
 ---
 
 <style>
-  .appstore-section {
+  .authority-strip {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 2rem;
-    margin-top: 2rem;
-    margin-bottom: 2rem;
-
-    @media (min-width: 520px) {
-      flex-direction: row;
-      justify-content: center;
-      gap: 4rem;
-      margin-top: 4rem;
-      margin-bottom: 4rem;
-    }
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
 
     @media (min-width: 800px) {
-      gap: 7rem;
+      flex-direction: row;
+      gap: 2rem;
+      margin-top: 2rem;
+      margin-bottom: 2rem;
     }
   }
 
+  .authority-strip__badges {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1.5rem;
+
+    @media (min-width: 800px) {
+      gap: 2rem;
+    }
+  }
+
+  .authority-strip__copy {
+    margin: 0;
+
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.4;
+    color: #c8c8c8;
+    text-align: center;
+    text-wrap: balance;
+
+    @media (min-width: 800px) {
+      font-size: 1rem;
+    }
+  }
+
+  .authority-strip__copy strong {
+    color: #fff;
+    font-weight: 600;
+  }
+
+  .authority-strip__divider {
+    margin: 0 0.5em;
+
+    color: #555;
+  }
+
   .image {
-    width: 10.5rem;
+    width: 5.25rem;
     height: auto;
+
+    @media (min-width: 800px) {
+      width: 6.5rem;
+    }
   }
 </style>
 
 <section
-  class="deprecated-grid appstore-section"
-  aria-label="App Store badges"
+  class="deprecated-grid authority-strip"
+  aria-label="App Store credibility"
   data-aos="fade-in"
 >
-  <a
-    href="https://apps.apple.com/app/apple-store/id1504940162?pt=117264678&ct=Landing%20Page%20or%20Form%20-%208653523&mt=8"
-    target="_blank"
-    rel="noopener"
-    class="plausible-event-name=App+Store+Install plausible-event-surface=landing plausible-event-placement=landing-app-store-reviews plausible-event-format=badge"
-  >
-    <Image
-      src={appStoreReview}
-      alt='"4.8 Rating" badge from the Apple App Store, with five gold stars. The badge is black with white text and a white Apple logo, surrounded by a laurel wreath. Text at the bottom reads "App Store Reviews."'
-      width="336"
-      class="image"
-    />
-  </a>
-  <a
-    href="https://apps.apple.com/app/apple-store/id1504940162?pt=117264678&ct=Landing%20Page%20or%20Form%20-%208653523&mt=8"
-    target="_blank"
-    rel="noopener"
-    class="plausible-event-name=App+Store+Install plausible-event-surface=landing plausible-event-placement=landing-app-store-featured plausible-event-format=badge"
-  >
-    <Image
-      src={appStoreFeatured}
-      alt='"Essential Apps for Developers" badge from the Apple App Store. The badge is black with white text and a white Apple logo, surrounded by a laurel wreath.'
-      width="336"
-      class="image"
-    />
-  </a>
+  <div class="authority-strip__badges">
+    <a
+      href={appStoreHref}
+      target="_blank"
+      rel="noopener"
+      class="plausible-event-name=App+Store+Install plausible-event-surface=landing plausible-event-placement=landing-app-store-reviews plausible-event-format=badge"
+    >
+      <Image
+        src={appStoreReview}
+        alt='"4.8 Rating" badge from the Apple App Store, with five gold stars and a laurel wreath.'
+        width="208"
+        class="image"
+      />
+    </a>
+    <a
+      href={appStoreHref}
+      target="_blank"
+      rel="noopener"
+      class="plausible-event-name=App+Store+Install plausible-event-surface=landing plausible-event-placement=landing-app-store-featured plausible-event-format=badge"
+    >
+      <Image
+        src={appStoreFeatured}
+        alt='"Essential Apps for Developers" Apple Featured badge with a laurel wreath.'
+        width="208"
+        class="image"
+      />
+    </a>
+  </div>
+  <p class="authority-strip__copy">
+    <strong>★4.8 on the App Store</strong>
+    <span class="authority-strip__divider" aria-hidden="true">·</span>
+    Apple Featured: Essential Apps for Developers
+    <span class="authority-strip__divider" aria-hidden="true">·</span>
+    <strong>25,000+ developers</strong>
+    <span class="authority-strip__divider" aria-hidden="true">·</span>
+    <strong>250+ teams</strong>
+  </p>
 </section>

--- a/docs/src/old/components/Features.astro
+++ b/docs/src/old/components/Features.astro
@@ -3,20 +3,30 @@ import { getCollection, render } from "astro:content";
 
 import Feature from "@/components/Feature.astro";
 
+interface Props {
+  take?: number;
+  skip?: number;
+}
+
+const { take, skip = 0 } = Astro.props;
+
 const rawFeatures = await getCollection(
   "feature",
   (entry) => entry.data.showOnHomepage === true,
 );
+const sortedFeatures = rawFeatures.sort((a, b) => a.id.localeCompare(b.id));
+const slicedFeatures = sortedFeatures.slice(
+  skip,
+  take !== undefined ? skip + take : undefined,
+);
 const features = await Promise.all(
-  rawFeatures
-    .sort((a, b) => a.id.localeCompare(b.id))
-    .map(async (feature) => {
-      const { Content } = await render(feature);
-      return {
-        ...feature,
-        Content,
-      };
-    }),
+  slicedFeatures.map(async (feature) => {
+    const { Content } = await render(feature);
+    return {
+      ...feature,
+      Content,
+    };
+  }),
 );
 ---
 

--- a/docs/src/old/components/Header.astro
+++ b/docs/src/old/components/Header.astro
@@ -5,9 +5,11 @@ import appIcon from "../../assets/rocketsim-app-icon.png";
 
 interface Props {
   title: string;
+  logo?: ImageMetadata;
+  logoAlt?: string;
 }
 
-const { title } = Astro.props;
+const { title, logo, logoAlt } = Astro.props;
 ---
 
 <style>
@@ -26,6 +28,29 @@ const { title } = Astro.props;
   .hero__content {
     @media (min-width: 800px) {
       grid-column: 1 / span 7;
+    }
+  }
+
+  .hero__wordmark {
+    display: inline-flex;
+    margin: 0 0 1rem;
+  }
+
+  .hero__wordmark a {
+    display: inline-flex;
+
+    &:focus-visible {
+      outline: 0.125rem solid var(--ring);
+      border-radius: 0.25rem;
+    }
+  }
+
+  .hero__wordmark-image {
+    width: 10rem;
+    height: auto;
+
+    @media (min-width: 800px) {
+      width: 16rem;
     }
   }
 
@@ -64,6 +89,20 @@ const { title } = Astro.props;
 <header>
   <div class="deprecated-grid hero">
     <div class="hero__content">
+      {
+        logo && (
+          <div class="hero__wordmark" id="hero-wordmark">
+            <a href="/" aria-label="RocketSim">
+              <Image
+                src={logo}
+                alt={logoAlt ?? "RocketSim"}
+                height="48"
+                class="hero__wordmark-image"
+              />
+            </a>
+          </div>
+        )
+      }
       <h1>{title}</h1>
       <p>
         <slot />

--- a/docs/src/old/components/Navigation.astro
+++ b/docs/src/old/components/Navigation.astro
@@ -25,7 +25,8 @@ const { showLogin = false, microcopy } = Astro.props;
   nav {
     @media (min-width: 800px) {
       display: flex;
-      align-items: center;
+      flex-direction: column;
+      align-items: flex-start;
       grid-column: 1 / -2;
     }
   }
@@ -43,11 +44,15 @@ const { showLogin = false, microcopy } = Astro.props;
   }
 
   .navigation__microcopy {
-    margin: 0.375rem 0 0;
+    margin: 0.75rem 0 0;
 
     font-size: 0.75rem;
     color: #888;
     text-align: center;
+
+    @media (min-width: 800px) {
+      text-align: left;
+    }
   }
 
   .navigation__right-column {

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -16,6 +16,8 @@ import SocialMediaMentions from "../old/components/SocialMediaMentions.astro";
 import SubscribeToNewsletter from "../old/components/SubscribeToNewsletter.astro";
 import SupportAndFeedback from "../old/components/SupportAndFeedback.astro";
 
+import TrustedBrands from "@/partials/TrustedBrands.astro";
+
 const {
   site: { base_url, title: siteTitle },
   metadata: { meta_description },
@@ -57,6 +59,7 @@ const seo = {
     >
   </Navigation>
   <AppStore />
+  <TrustedBrands title="Used by iOS developers at" />
   <Reviews />
   <SubscribeToNewsletter />
   <Features />

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -17,6 +17,9 @@ import SubscribeToNewsletter from "../old/components/SubscribeToNewsletter.astro
 import SupportAndFeedback from "../old/components/SupportAndFeedback.astro";
 
 import TrustedBrands from "@/partials/TrustedBrands.astro";
+import CallToAction from "@/partials/CallToAction.astro";
+
+import logoImage from "../assets/rocketsim-logo.svg";
 
 const {
   site: { base_url, title: siteTitle },
@@ -35,6 +38,8 @@ const seo = {
   <Notification />
   <Header
     title="The iOS Simulator companion for developers and AI coding agents."
+    logo={logoImage}
+    logoAlt='Written logo spelling: "RocketSim"'
   >
     RocketSim lets you <strong>inspect, test, and debug</strong> your app in the Simulator
     — without breaking your flow in Xcode, Codex, or Cursor.
@@ -60,9 +65,10 @@ const seo = {
   </Navigation>
   <AppStore />
   <TrustedBrands title="Used by iOS developers at" />
+  <Features take={3} />
   <Reviews />
-  <SubscribeToNewsletter />
-  <Features />
+  <CallToAction />
+  <Features skip={3} />
   <TeamInsights />
   <StatusBar />
   <SubscribeToNewsletter />

--- a/docs/src/styles/navigation.css
+++ b/docs/src/styles/navigation.css
@@ -9,9 +9,18 @@
 
 .navbar-brand {
   @apply text-[0rem] font-semibold text-text-dark;
+  transition:
+    opacity 250ms ease,
+    visibility 250ms ease;
   image {
     @apply max-h-full max-w-full;
   }
+}
+
+.navbar-brand.is-shy {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
 }
 
 .navbar-nav {


### PR DESCRIPTION
## Summary

PR 2 of 2 applying [page-cro](https://github.com/AvdLee/RocketSimApp/blob/master/docs/.agents/skills/page-cro/SKILL.md) + [marketing-psychology](https://github.com/AvdLee/RocketSimApp/blob/master/docs/.agents/skills/marketing-psychology/SKILL.md) to the homepage.

**Targets `docs/homepage-cro-quick-wins` (PR #1028)** so both PRs can be reviewed and run locally together. Includes the original social-proof restructure plus two follow-up polish commits driven by reviewing the live preview.

## What changes

### 1. Slim authority strip (commit 1)
Two large App Store badges side-by-side become one slim row. Vertical margins drop from 4rem to 2rem so it reads as a credibility strip, not a section. Both badges remain clickable, separate Plausible events preserved.

### 2. Homepage logo strip (commit 1)
Reuse the existing `TrustedBrands` partial on the homepage, between the authority strip and the Senja carousel. New optional `title` prop on `TrustedBrands` so the homepage can read *"Used by iOS developers at"* without affecting `/for-teams`.

### 3. Microcopy placement fix (commit 2)
On desktop, `Navigation` was `display: flex; align-items: center;`, which placed the `<ul>` of CTAs and the microcopy `<p>` side-by-side. Switched to `flex-direction: column; align-items: flex-start;` so the microline renders on its own line directly under the `Free download` button.

### 4. App Store strip rebalance (commit 2)
Trimmed the redundant copy. Badges already encode ★ 4.8 and Apple-Featured visually, repeating them in text reads as over-stacked authority. Copy line now reads **25,000+ developers · 250+ teams** — the new info the badges don't show. Centered horizontally on desktop, stacked on mobile.

### 5. Hero wordmark restored + shy top-nav wordmark (commit 3)
- The big *"RocketSim"* script wordmark is back above the homepage H1.
- The top-nav wordmark fades out while the hero wordmark is in view, then fades back in once you scroll past it (`IntersectionObserver` on `#hero-wordmark` toggles an `is-shy` class on `.navbar-brand`).
- Pages without `#hero-wordmark` (`/for-teams`, `/terms`, `/privacy`, docs, blog) keep the nav wordmark visible at all times.

### 6. Mid-page reorder (commit 3)
The AIDA funnel previously jumped Attention → Desire (testimonials) → Interest (features), then dribbled out. New order:

| Order | Section | AIDA stage |
|---|---|---|
| 1 | Hero | Attention |
| 2 | Slim authority strip + brand logos | Light authority |
| 3 | **Top 3 features** | Interest |
| 4 | **Senja testimonial carousel** (moved here) | Desire |
| 5 | **CallToAction banner** (new on homepage) | Action |
| 6 | Remaining 18 features, Team Insights, Status Bar, Newsletter, Social, Support | Continued discovery |

Implementation: `Features.astro` now accepts optional `take` / `skip` props so the same component renders both slices. The early duplicate `SubscribeToNewsletter` is dropped (its position no longer makes sense once Reviews moves down); the late one stays as the single newsletter touchpoint.

## Honest numbers

- **25,000+ developers** = unique users in the past 365 days (App Store Connect).
- **250+ teams** = current active teams.

## Files

- `docs/src/old/components/AppStore.astro` — slim authority strip, then centered + trimmed.
- `docs/src/old/components/Navigation.astro` — column-flex on desktop, microcopy now stacks below CTAs.
- `docs/src/old/components/Header.astro` — optional `logo` / `logoAlt` props re-introduced; renders the big wordmark above the H1 inside `#hero-wordmark` when provided.
- `docs/src/old/components/Features.astro` — optional `take` / `skip` props.
- `docs/src/layouts/Base.astro` — new `shyNavLogoInit` script with `IntersectionObserver`.
- `docs/src/styles/navigation.css` — `.navbar-brand.is-shy` modifier + opacity transition.
- `docs/src/layouts/partials/TrustedBrands.astro` — optional `title` prop.
- `docs/src/pages/index.astro` — full mid-page reorder, hero wordmark passed back in, `CallToAction` added.

## Test plan

- [ ] Hero shows the big script wordmark above the H1; rocket app icon still on the right.
- [ ] Microcopy *"Get started for free, no signup. Works with Xcode 16+."* renders on its own line directly under the `Free download` button.
- [ ] App Store strip is centered, badges intact and clickable, copy line reads **25,000+ developers · 250+ teams**, no rating/Apple-Featured text duplication.
- [ ] Scroll past the hero → top-nav wordmark fades in. Scroll back to top → fades out.
- [ ] `/for-teams`, `/terms`, `/privacy` show the top-nav wordmark at all times (unchanged).
- [ ] Homepage section order: top 3 features → Senja testimonial carousel → `CallToAction` banner → remaining 18 features → Team Insights → Status Bar → Newsletter → Social → Support.
- [ ] `Free download` button still fires `App+Store+Install` Plausible event and the UTM-rewrite script still rewrites `#js-header-app-store-button`.
- [ ] Both App Store badges still link out and still fire `App+Store+Install` events with separate `placement=landing-app-store-reviews` / `placement=landing-app-store-featured` props.
- [ ] `/for-teams` logo strip unchanged (*"Trusted by developers at leading tech companies."*).
- [ ] CI quality gate: `npm run lint && npm run format:check && npm run typecheck && npm run build` all pass.

## Reviewer note

Once PR #1028 merges, GitHub auto-retargets this PR to `master`.