### PR TITLE
Position homepage form around RocketSim updates

### DIFF
--- a/docs/src/old/components/SubscribeToNewsletter.astro
+++ b/docs/src/old/components/SubscribeToNewsletter.astro
@@ -19,10 +19,10 @@ import NewsLetterForm from "./NewsLetterForm.astro";
 <section>
   <div data-aos="fade-in">
     <SectionHeader
-      title="Try RocketSim Pro free for 14 days"
-      subtitle="Your productivity boost starts now."
+      title="Stay ahead of what's new in RocketSim"
+      subtitle="Feature updates for iOS developers using the Simulator."
       smallTitle
-      text="Discover features that help you code, test, and ship faster than ever. No credit card required. Just tools that make you a faster iOS developer."
+      text="Get new RocketSim releases, beta invites, workflow improvements, and early-access announcements in your inbox."
     />
     <NewsLetterForm />
   </div>


### PR DESCRIPTION
## Summary
- Reframe the homepage Kit form around RocketSim release updates, beta invites, workflow improvements, and early-access announcements.
- Align the landing page promise with the updated Kit button copy: "Get RocketSim Updates".

## Test plan
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm run knip