### PR TITLE
Add SEO blog article: How to Test VoiceOver on the Xcode Simulator

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -138,6 +138,7 @@ When opening local docs pages in the browser:
 - Always use the configured trailing slash (for example, `http://localhost:4322/docs/features/networking/network-speed-control/`) to avoid stale optimized image URLs or route mismatches.
 
 Available shortcodes (auto-imported, no import statement needed):
+
 - `<Youtube id="..." title="..." />` — embeds a YouTube video
 - `<Accordion>` — collapsible content
 - `<Tweet />` — embedded tweet
@@ -147,3 +148,38 @@ The documentation also generates `llms.txt` and `llms-full.txt` files via the `s
 ### Blog
 
 The blog is powered by a headless WordPress instance. Blog posts are fetched at build time and statically rendered.
+
+Static, hand-coded blog articles live in `src/pages/blog/<slug>.astro` and use the `Base` layout with full `seo` and `structuredData` props. Use them for SEO-targeted articles where we want full control over markup, internal linking, and image handling.
+
+## Writing Blog Articles
+
+When writing or editing blog articles (both static `.astro` posts in `src/pages/blog/` and WordPress drafts):
+
+### Typographic conventions
+
+- **Use `→` (U+2192) for menu paths and step sequences**, never `>` or `&gt;`. For example: `Settings → Accessibility → VoiceOver`, not `Settings > Accessibility > VoiceOver`. This avoids ambiguity with HTML/MDX comparison operators and reads better.
+- Use em dashes (`—`, U+2014) for parenthetical asides, not double hyphens.
+- Use real Unicode arrows for keyboard shortcuts in body text: `↑`, `↓`, `←`, `→`, `⏎`, `Esc`, `⌘`. Wrap them in `<strong>` when listing shortcuts.
+
+### Voice and tone
+
+Articles are written in Antoine van der Lee's voice. Match the existing pattern in `src/pages/blog/15-voiceover-navigator-pro-xcode-simulator-recordings.astro` and `src/pages/blog/how-to-test-voiceover-on-the-xcode-simulator.astro`:
+
+- Direct, opinionated, practitioner voice — not academic.
+- Second person (`you`) for the reader; first person (`I`) for personal asides.
+- Short paragraphs (3–4 sentences max), variable sentence rhythm.
+- No filler openers like "In this section, we will…" or "Let's dive into…".
+- Standard closing pattern: short conclusion paragraph, then a CTA paragraph linking to the Mac App Store (with a `ct=` UTM parameter unique to the article), and end with `Thanks!`.
+
+### SEO requirements
+
+Every static blog article must:
+
+- Have a unique `slug`, `title`, `description`, `publishedTime`, and `modifiedTime`.
+- Keep the `<title>` tag (including ` - RocketSim` suffix) **≤ 60 characters**. If the headline you want to display is longer, declare a separate `pageTitle` constant for the visible `<h1>` and keep `title` short.
+- Keep the meta `description` **≤ 160 characters**, include the primary keyword once, and read as a self-contained value proposition.
+- Place the primary keyword in the URL slug, `<title>`, `<h1>`, the first paragraph, and at least one `<h2>`.
+- Pass `structuredData={{ type: "article", article: { … } }}` so the `Article` + `WebPage` + `BreadcrumbList` JSON-LD graph is emitted automatically.
+- Include at least two internal links (typically one to `/docs/features/<area>/<page>` and one to `/features/<area>`) and one authoritative external link (usually Apple developer documentation).
+- Provide descriptive, keyword-aware `alt` text on every image. Reuse images from `src/assets/blog/<release>/`, `src/assets/features/`, or `src/content/docs/...` instead of duplicating files.
+- Append a Mac App Store install link with a `ct=<article-slug>` UTM parameter in the CTA so installs from the article are attributable.

--- a/docs/src/pages/blog/how-to-test-voiceover-on-the-xcode-simulator.astro
+++ b/docs/src/pages/blog/how-to-test-voiceover-on-the-xcode-simulator.astro
@@ -1,0 +1,365 @@
+---
+import { Image } from "astro:assets";
+
+import Base from "@/layouts/Base.astro";
+import config from "@/config/config.json";
+
+import voiceOverHero from "../../assets/blog/rocketsim-15/voiceover-accessibility-overlay-white.png";
+import voiceOverOverlay from "../../content/docs/docs/features/accessibility/voiceover-navigator/voiceover-overlay.png";
+import voiceOverNavigation from "../../content/docs/docs/features/accessibility/voiceover-navigator/voiceover-navigation.png";
+import liquidGlassCompare from "../../assets/features/liquid-glass-accessibility-testing-compare.jpg";
+
+const slug = "how-to-test-voiceover-on-the-xcode-simulator";
+const title = "How to Test VoiceOver on the Xcode Simulator";
+const pageTitle = `${title} (Without a Physical Device)`;
+const description =
+  "Test VoiceOver on the Xcode Simulator without a physical device. Use a numbered overlay, keyboard shortcuts, and the rotor to verify iOS accessibility fast.";
+const publishedTime = "2026-05-28T09:00:00.000Z";
+const modifiedTime = publishedTime;
+const canonicalUrl = `${config.site.base_url}/blog/${slug}`;
+const image = `${config.site.base_url}${voiceOverHero.src}`;
+
+const seo = {
+  title: `${title} - RocketSim`,
+  description,
+  image,
+  canonical: canonicalUrl,
+  twitterCreator: "@twannl",
+  twitterSite: "@rocketsim_app",
+  article: {
+    publishedTime,
+    modifiedTime,
+  },
+};
+
+const structuredData = {
+  type: "article" as const,
+  article: {
+    headline: pageTitle,
+    description,
+    datePublished: publishedTime,
+    dateModified: modifiedTime,
+    url: canonicalUrl,
+    slug,
+    image: {
+      url: image,
+    },
+  },
+};
+---
+
+<Base seo={seo} structuredData={structuredData}>
+  <article>
+    <header>
+      <div class="ph-spacing">
+        <div class="container text-center">
+          <div class="flex flex-col items-center gap-16 lg:gap-28">
+            <div class="space-y-3 md:space-y-5 mx-auto">
+              <p
+                class="text-center text-base font-medium text-text pb-2"
+                data-aos="fade-up-sm"
+                data-aos-delay="0"
+              >
+                May 28, 2026
+              </p>
+              <h1
+                class="page-heading leading-none text-center !mb-6"
+                data-aos="fade-up-sm"
+                data-aos-delay="50"
+              >
+                {pageTitle}
+              </h1>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="ph-merged-section">
+        <div class="container">
+          <figure data-aos="fade-up-sm" data-aos-delay="150">
+            <Image
+              src={voiceOverHero}
+              alt="VoiceOver testing on the Xcode Simulator with RocketSim, showing numbered accessibility elements overlaid on the iPhone Simulator and the Voice Over Elements list."
+              class="w-full max-h-[580px] object-cover rounded-2xl"
+            />
+          </figure>
+        </div>
+      </div>
+    </header>
+
+    <section class="section -mt-20">
+      <div class="container">
+        <div class="content xl:px-32">
+          <p>
+            <strong>Testing VoiceOver on the Xcode Simulator</strong>
+            is one of those tasks every iOS developer agrees is important, and most
+            developers postpone until the last minute. The Xcode Simulator does not
+            ship with a real VoiceOver runtime, so the usual answer is "grab a physical
+            iPhone, enable VoiceOver in Settings, and start swiping." That works,
+            but it pulls you out of your normal development flow and slows down every
+            small fix.
+          </p>
+
+          <p>
+            This article walks through the practical options you have today. You
+            will see what Xcode itself offers, why the physical-device workflow
+            is still painful, and how RocketSim turns VoiceOver testing into a
+            keyboard-driven step you can run inside the Simulator while you
+            develop. The goal is simple: make accessibility checks fast enough
+            that you actually run them.
+          </p>
+
+          <h2>Why VoiceOver testing belongs in your daily iOS workflow</h2>
+
+          <p>
+            VoiceOver is the most visible accessibility feature on iOS, and it
+            is the one most likely to break silently when you change a layout.
+            Adding a wrapping <code>VStack</code> or renaming an icon button can flip
+            the reading order in a way you never see visually, but a VoiceOver user
+            will hit immediately. The earlier you catch it, the cheaper it is to fix.
+          </p>
+
+          <p>
+            In my experience, the main reason accessibility regressions ship is
+            not a lack of care — it is friction. If verifying a single screen
+            takes ten minutes of device juggling, you will not do it on every
+            pull request. If it takes ten seconds in the Simulator, you will.
+            That is the loop this article tries to give you.
+          </p>
+
+          <h2>
+            What you can (and cannot) do with VoiceOver in the Xcode Simulator
+          </h2>
+
+          <p>
+            The honest answer is that <strong
+              >the Xcode Simulator does not run real VoiceOver</strong
+            >. There is no Settings toggle that turns it on the way you would on
+            an iPhone, and the triple-click side-button shortcut does not exist
+            either. The Simulator is a great development tool, but it is not
+            designed to be a screen reader sandbox.
+          </p>
+
+          <p>
+            What you do have is <a
+              href="https://developer.apple.com/documentation/accessibility/accessibility-inspector"
+              >Xcode's Accessibility Inspector</a
+            >. It can target a running Simulator, list accessibility elements,
+            highlight them on hover, and run audits for missing labels or low
+            contrast. It is genuinely useful for debugging a specific element,
+            but it is not a substitute for stepping through the app the way
+            VoiceOver actually does. You see metadata, not behavior.
+          </p>
+
+          <p>
+            That gap — inspecting elements versus moving through them — is
+            exactly the reason most developers fall back to a physical device
+            once they want to verify a full screen or flow.
+          </p>
+
+          <h2>The physical-device workflow (and why it slows you down)</h2>
+
+          <p>
+            On a physical iPhone, you enable VoiceOver from <strong
+              >Settings → Accessibility → VoiceOver</strong
+            > and bind the Accessibility Shortcut to a triple-click of the side button.
+            From there you swipe right and left to move through elements, double-tap
+            to activate, and rotate two fingers to switch rotor categories. It works,
+            and it is the most accurate way to experience your app the way a VoiceOver
+            user would.
+          </p>
+
+          <p>
+            The problem is the development loop around it. You build and deploy
+            to the device, switch focus from Xcode to your phone, enable
+            VoiceOver, find the bug, disable VoiceOver so you can use the
+            keyboard again, walk back to Xcode, change one line, and repeat.
+            Every iteration breaks your context.
+          </p>
+
+          <p>
+            You will still want to validate critical flows on a real device
+            before shipping. But for the dozens of small fixes you make while
+            building — reordering elements, adding labels, grouping a card,
+            tagging a heading — the device-based loop is too slow to use as your
+            default.
+          </p>
+
+          <h2>Testing VoiceOver on the Xcode Simulator with RocketSim</h2>
+
+          <p>
+            <a href="/docs/features/accessibility/voiceover-navigator"
+              >RocketSim's VoiceOver Navigator</a
+            > closes that gap. It runs alongside the Xcode Simulator and shows a numbered
+            overlay on every accessibility element in the exact order VoiceOver would
+            announce them. You see the reading order without listening to the reading
+            order — which is usually what you actually need while you are coding.
+          </p>
+
+          <figure>
+            <Image
+              src={voiceOverOverlay}
+              alt="RocketSim VoiceOver Elements Overlay on the iOS Simulator showing numbered accessibility elements, the rotor dropdown, and the Voice Over Elements list with roles like StaticText and Button."
+              class="w-full rounded-2xl"
+            />
+            <figcaption>
+              The Elements Overlay shows every accessibility element on top of
+              the Xcode Simulator, in VoiceOver order.
+            </figcaption>
+          </figure>
+
+          <p>
+            From the side window you turn on <strong>Elements Overlay</strong>
+            and pick a rotor category from the dropdown — for example <strong
+              >All Elements</strong
+            >, <strong>Headings</strong>, or <strong>Form Controls</strong>.
+            Each element gets a number and a row in the list with its role, so
+            you can immediately see whether a heading lands where you expect it
+            or whether a static text element accidentally became a button. The
+            element count at the bottom is a useful sanity check on its own.
+          </p>
+
+          <p>
+            Because the overlay is rendered live, it updates as your app
+            updates. Push a new view, hit <strong>Refresh</strong>, and the
+            numbering re-runs. There is no device build, no toggling, no
+            triple-click — you stay on the Mac, in your editor.
+          </p>
+
+          <h2>
+            Navigating elements with the keyboard, like a real VoiceOver swipe
+          </h2>
+
+          <p>
+            Inspecting elements is useful, but VoiceOver is fundamentally about <strong
+              >movement</strong
+            >. To replicate that loop on the Simulator, click <strong
+              >Start Navigating</strong
+            > in the Voice Over panel. The overlay stays on screen and the focus highlight
+            jumps between elements as you press the arrow keys.
+          </p>
+
+          <figure>
+            <Image
+              src={voiceOverNavigation}
+              alt="RocketSim VoiceOver Navigator in navigation mode on the Xcode Simulator, with the keyboard shortcuts panel showing arrow keys, Enter, and Esc, and the currently focused Watchlist button highlighted."
+              class="w-full rounded-2xl"
+            />
+            <figcaption>
+              Navigation mode highlights the focused element and lists the
+              keyboard shortcuts for moving through the rotor.
+            </figcaption>
+          </figure>
+
+          <p>The shortcuts map directly onto VoiceOver gestures:</p>
+
+          <ul>
+            <li>
+              <strong>↑ / ↓</strong> — Move to the previous or next element in VoiceOver
+              order, exactly like swiping left or right on device.
+            </li>
+            <li>
+              <strong>← / →</strong> — Switch rotor category, the way a two-finger
+              rotate would on a real iPhone.
+            </li>
+            <li>
+              <strong>⏎ Enter</strong> — Activate the focused element, similar to
+              a double-tap; the app navigates and the overlay updates with the new
+              screen.
+            </li>
+            <li>
+              <strong>Esc</strong> — Exit navigation mode and return to the overlay-only
+              view.
+            </li>
+          </ul>
+
+          <p>
+            This is the part that makes accessibility testing feel like part of
+            the build cycle rather than a separate phase. You step through a
+            screen, spot a missing label or a wrong rotor group, fix it in
+            Xcode, hit <strong>Refresh</strong>, and verify in seconds. No
+            cable, no headphones, no losing your place.
+          </p>
+
+          <h2>
+            Combine VoiceOver with the rest of your iOS accessibility checks
+          </h2>
+
+          <p>
+            VoiceOver is the headline feature, but accessibility on iOS is a
+            stack: Dynamic Type, Bold Text, Increase Contrast, Reduce Motion,
+            Reduce Transparency, and now Tinted Liquid Glass. A screen that
+            reads well in VoiceOver can still fail badly at the largest Dynamic
+            Type size or under Increase Contrast.
+          </p>
+
+          <p>
+            From the same side window, RocketSim's <a
+              href="/docs/features/accessibility/environment-overrides"
+              >Environment Overrides</a
+            >
+            give you direct toggles for those settings, plus a slider for every <a
+              href="/docs/features/accessibility/toggles-and-dynamic-text"
+              >Dynamic Type</a
+            >
+            size. So once you finish a VoiceOver pass, you can flip on Bold Text,
+            crank up Dynamic Type, and check the same screen again — without going
+            back into Simulator Settings.
+          </p>
+
+          <figure>
+            <Image
+              src={liquidGlassCompare}
+              alt="Side-by-side comparison of an iOS app on the Xcode Simulator before and after enabling Tinted Liquid Glass through RocketSim's accessibility toggles."
+              class="w-full rounded-2xl"
+            />
+            <figcaption>
+              Tinted Liquid Glass is one of several accessibility toggles you
+              can flip from the same panel as VoiceOver Navigator.
+            </figcaption>
+          </figure>
+
+          <p>
+            If you treat VoiceOver as one stop in a short accessibility
+            checklist — VoiceOver order, headings, Dynamic Type, contrast — you
+            will catch most of the regressions that normally slip through until
+            App Review or a user report. The full set of <a
+              href="/features/accessibility">RocketSim accessibility features</a
+            > is built around exactly this kind of fast iteration loop on the Xcode
+            Simulator.
+          </p>
+
+          <h2><strong>Conclusion</strong></h2>
+
+          <p>
+            For a long time, "test VoiceOver on the Xcode Simulator" really
+            meant "give up and use a physical device." That is no longer true.
+            With a numbered Elements Overlay, a keyboard-driven navigator, and a
+            rotor that matches the device experience, you can verify the reading
+            order and activation flow of an iOS app without leaving the
+            Simulator. A physical device is still the right place for a final
+            pass, but it should not be your default anymore.
+          </p>
+
+          <p>
+            If you want to try this on your own app, install <a
+              href="https://apps.apple.com/app/apple-store/id1504940162?pt=117264678&ct=voiceover-article&mt=8"
+              >RocketSim from the Mac App Store</a
+            >
+            and open the <strong>Voice Over</strong> tab in the side window. You can
+            also dig into the full <a
+              href="/docs/features/accessibility/voiceover-navigator"
+              >VoiceOver Navigator documentation</a
+            >
+            for the keyboard shortcuts and rotor details. Feel free to reach out on
+            <a href="https://x.com/twannl">X/Twitter</a> or
+            <a href="https://github.com/AvdLee/RocketSimApp/issues"
+              >open an issue on GitHub</a
+            >
+            if you run into anything or have feature ideas. Thanks!
+          </p>
+        </div>
+      </div>
+    </section>
+  </article>
+</Base>


### PR DESCRIPTION
## Summary

- Adds a new static blog article at `/blog/how-to-test-voiceover-on-the-xcode-simulator/` targeting the search query *"how to test VoiceOver on the Xcode Simulator"* — a real pain point for iOS developers since the Simulator does not run VoiceOver.
- Frames the default device-only workflow as friction-heavy and positions RocketSim's VoiceOver Navigator (Elements Overlay + keyboard navigation + rotor) as the in-Simulator answer.
- Closes the conversion loop with an attributable Mac App Store install link (`ct=voiceover-article`).
- Reuses existing visuals from `src/assets/blog/rocketsim-15/`, `src/content/docs/.../voiceover-navigator/`, and `src/assets/features/` — no new image files added.
- Adds a new **"Writing Blog Articles"** section to `docs/AGENTS.md` codifying the voice, typography (`→` instead of `>` for menu paths, real Unicode arrows for keyboard shortcuts), and SEO checklist used while writing this piece.

## SEO highlights

- Primary keyword *"test VoiceOver on the Xcode Simulator"* placed in URL slug, `<title>`, `<h1>`, first paragraph, one `<h2>`, conclusion, and image alt text.
- `<title>` 56 chars (within SERP limit) and meta `description` 156 chars (within 160).
- Full schema.org JSON-LD graph: `Article` + `Person` (Antoine) + `Organization` + `WebPage` + `BreadcrumbList`.
- 4 internal links + 1 authoritative external link (Apple's Accessibility Inspector documentation).

## Test plan

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run knip`
- [x] Verified rendered HTML locally at `http://127.0.0.1:4322/blog/how-to-test-voiceover-on-the-xcode-simulator/` — title, meta description, canonical URL, OG/Twitter cards, and JSON-LD all correct.
- [x] Confirmed production build emits hashed `_astro/*.png` image URLs (no dev-only `@fs/` paths leak).
- [ ] Review article copy in Antoine's voice — comfortable with tone, openings, and closing CTA?
- [ ] Confirm the `ct=voiceover-article` UTM convention matches how App Store install attribution is reported.