### PR TITLE
Clarify pricing and team conversion copy

### DIFF
--- a/docs/src/content/docs/docs/features/accessibility/voiceover-navigator.md
+++ b/docs/src/content/docs/docs/features/accessibility/voiceover-navigator.md
@@ -3,8 +3,8 @@ title: "VoiceOver Navigator"
 description: "Visualize VoiceOver element order on the iOS Simulator with numbered overlays. Navigate elements with keyboard shortcuts and verify reading order without a device."
 ---
 
-::::note
-VoiceOver Navigator is available as a Pro feature in RocketSim 15.
+::::tip[Check accessibility faster]
+VoiceOver Navigator helps you verify reading order and activation flow without leaving the Simulator. It is included with RocketSim Pro.
 ::::
 
 Testing VoiceOver used to mean grabbing a physical device, enabling VoiceOver, and swiping through your app. VoiceOver Navigator lets you stay in the Simulator: you get a visual overlay of the accessibility element order and keyboard-driven navigation, so you can verify reading order and rotor behavior without leaving your flow.

--- a/docs/src/content/docs/docs/features/accessibility/voiceover-navigator.md
+++ b/docs/src/content/docs/docs/features/accessibility/voiceover-navigator.md
@@ -4,7 +4,7 @@ description: "Visualize VoiceOver element order on the iOS Simulator with number
 ---
 
 ::::tip[Check accessibility faster]
-VoiceOver Navigator helps you verify reading order and activation flow without leaving the Simulator. It is included with RocketSim Pro.
+VoiceOver Navigator helps you verify reading order and activation flow without leaving the Simulator.
 ::::
 
 Testing VoiceOver used to mean grabbing a physical device, enabling VoiceOver, and swiping through your app. VoiceOver Navigator lets you stay in the Simulator: you get a visual overlay of the accessibility element order and keyboard-driven navigation, so you can verify reading order and rotor behavior without leaving your flow.

--- a/docs/src/content/docs/docs/features/build-insights/team-build-insights.md
+++ b/docs/src/content/docs/docs/features/build-insights/team-build-insights.md
@@ -19,6 +19,10 @@ RocketSim silently syncs build data in the background. It syncs at most once per
 
 Team Build Insights requires a Pro subscription with a team license key. Once configured, data flows automatically.
 
+:::tip[For engineering managers]
+Use Team Build Insights when you need evidence for hardware upgrades, Xcode rollouts, or SDK changes. RocketSim gives you project-specific build data without adding build phases or maintaining internal scripts.
+:::
+
 ## Online dashboard
 
 Team insights are available at [teams.rocketsim.app](https://teams.rocketsim.app). You get a web-based overview of your team's build performance, so you can compare machines and spot trends without opening RocketSim.
@@ -47,4 +51,18 @@ Teams that use Team Build Insights often say the same thing: once you see build 
 >
 > — Max Godfrey, iOS Developer at Tilt
 
-If you're on a team, a [team license](https://www.rocketsim.app) gives everyone this visibility — no extra setup, no build phase scripts. You get the dashboard, the P95 breakdowns by machine and Xcode, and data that backs up hardware and tooling decisions. Worth checking out if you've ever wondered how your build times compare to the rest of the team.
+If you're on a team, a [team license](https://www.rocketsim.app/pricing#plan-teams) gives everyone this visibility — no extra setup, no build phase scripts. You get the dashboard, the P95 breakdowns by machine and Xcode, and data that backs up hardware and tooling decisions. Worth checking out if you've ever wondered how your build times compare to the rest of the team.
+
+## Common team questions
+
+**We already track CI build times. Why track local builds too?**
+
+CI tells you how your pipeline performs. Team Build Insights shows the build time developers feel during the day, grouped by machine, Xcode version, macOS version, project, and scheme.
+
+**Do we need to add build phases or scripts?**
+
+No. RocketSim tracks build data in the background and syncs at most once per hour.
+
+**How do we try this with a team?**
+
+[Start a 14-day Teams trial](https://teams.rocketsim.app/signup/trial) and connect developers with the same team license key. No credit card is required.

--- a/docs/src/content/docs/docs/features/capturing/120-fps-recordings.md
+++ b/docs/src/content/docs/docs/features/capturing/120-fps-recordings.md
@@ -3,10 +3,6 @@ title: "120 FPS Recordings"
 description: "Record smooth 120 FPS videos from the iOS Simulator for high-quality App Preview videos and marketing materials. Requires Apple Silicon."
 ---
 
-:::note
-120 FPS Recordings is available in the latest RocketSim beta. [Join the beta via TestFlight](https://testflight.apple.com/join/emGszFpq) to try it out.
-:::
-
 Standard Simulator recordings run at 30 FPS. RocketSim's 120 FPS mode produces much smoother recordings, which makes a real difference for demo videos, presentations, and social media content.
 
 ## Enabling 120 FPS

--- a/docs/src/content/docs/docs/features/capturing/120-fps-recordings.md
+++ b/docs/src/content/docs/docs/features/capturing/120-fps-recordings.md
@@ -11,7 +11,11 @@ Standard Simulator recordings run at 30 FPS. RocketSim's 120 FPS mode produces m
 
 ## Enabling 120 FPS
 
-Open **RocketSim Settings → Captures** and enable **120 FPS Recordings**. This is a Pro feature. Once enabled, your recordings will capture at 120 frames per second instead of 30.
+Open **RocketSim Settings → Captures** and enable **120 FPS Recordings**. Once enabled, your recordings will capture at 120 frames per second instead of 30.
+
+::::tip[Make simulator demos feel smoother]
+120 FPS Recordings helps marketing videos, presentations, and app previews feel more polished. It is included with RocketSim Pro.
+::::
 
 ![RocketSim Settings → Captures with Enable 120 FPS recordings toggle](./120-fps-recordings/120-fps-setting.png)
 

--- a/docs/src/content/docs/docs/features/capturing/120-fps-recordings.md
+++ b/docs/src/content/docs/docs/features/capturing/120-fps-recordings.md
@@ -14,7 +14,7 @@ Standard Simulator recordings run at 30 FPS. RocketSim's 120 FPS mode produces m
 Open **RocketSim Settings → Captures** and enable **120 FPS Recordings**. Once enabled, your recordings will capture at 120 frames per second instead of 30.
 
 ::::tip[Make simulator demos feel smoother]
-120 FPS Recordings helps marketing videos, presentations, and app previews feel more polished. It is included with RocketSim Pro.
+120 FPS Recordings helps marketing videos, presentations, and app previews feel more polished.
 ::::
 
 ![RocketSim Settings → Captures with Enable 120 FPS recordings toggle](./120-fps-recordings/120-fps-setting.png)

--- a/docs/src/content/docs/docs/features/capturing/app-store-connect-optimization.md
+++ b/docs/src/content/docs/docs/features/capturing/app-store-connect-optimization.md
@@ -7,7 +7,11 @@ sidebar:
 
 App Store Connect rejects assets that don't match its exact specs: wrong resolution, wrong codec, PNG with transparency, or video without a proper audio track. Without RocketSim you end up resizing screenshots per device, converting PNG to JPEG and stripping alpha, re-encoding videos to H.264/HEVC, adding silent audio so previews don't get rejected, and trimming to the right duration — all while keeping [Apple's resolution table](https://help.apple.com/app-store-connect/?lang=en/#/dev4e413fcb8) open. It's tedious and easy to get wrong.
 
-RocketSim does it for you. Turn on **App Preview Optimized** once, and every screenshot and recording is converted to App Store Connect–ready specs. Capture, then drag into App Store Connect. No manual conversion, no rejections. This is a Pro feature.
+RocketSim does it for you. Turn on **App Preview Optimized** once, and every screenshot and recording is converted to App Store Connect–ready specs. Capture, then drag into App Store Connect. No manual conversion, no rejections.
+
+::::tip[Ship App Store assets with fewer manual steps]
+App Preview Optimized handles the tedious conversion work for screenshots and recordings. It is included with RocketSim Pro.
+::::
 
 ## How to enable
 

--- a/docs/src/content/docs/docs/features/capturing/app-store-connect-optimization.md
+++ b/docs/src/content/docs/docs/features/capturing/app-store-connect-optimization.md
@@ -10,7 +10,7 @@ App Store Connect rejects assets that don't match its exact specs: wrong resolut
 RocketSim does it for you. Turn on **App Preview Optimized** once, and every screenshot and recording is converted to App Store Connect–ready specs. Capture, then drag into App Store Connect. No manual conversion, no rejections.
 
 ::::tip[Ship App Store assets with fewer manual steps]
-App Preview Optimized handles the tedious conversion work for screenshots and recordings. It is included with RocketSim Pro.
+App Preview Optimized handles the tedious conversion work for screenshots and recordings so your captures are ready to upload faster.
 ::::
 
 ## How to enable

--- a/docs/src/content/docs/docs/features/capturing/app-store-connect-optimization.md
+++ b/docs/src/content/docs/docs/features/capturing/app-store-connect-optimization.md
@@ -31,24 +31,9 @@ Recordings are re-encoded to the correct codec (H.264 or HEVC). A silent audio t
 
 App Store Connect also enforces other rules for app previews: **length must be between 15 and 30 seconds**, file size is capped at 500MB, and there are requirements for frame rate, audio, and file format. RocketSim handles format and resolution; for duration and the full, up-to-date checklist, always check [Apple's official app preview specifications](https://help.apple.com/app-store-connect/?lang=en/#/dev4e413fcb8) so your previews are accepted.
 
-## Supported device resolutions
+## Supported output resolutions
 
-RocketSim maps each Simulator device to the right [App Store Connect resolution](https://help.apple.com/app-store-connect/?lang=en/#/dev4e413fcb8), so you don't have to look them up or resize by hand. Output resolutions include:
-
-**iPhone**
-
-- **886×1920** — 6.9", 6.5", 6.3", 6.1" (e.g. iPhone 16 Pro Max, 15 Plus, 14, 13, 12, X)
-- **1080×1920** — 5.5", 4" (e.g. iPhone 8 Plus, SE 1st gen)
-- **750×1334** — 4.7" (e.g. iPhone 8, SE 2nd/3rd gen)
-
-**iPad**
-
-- **1200×1600** — 13", 12.9", 11", 10.5" (Pro, Air, 10)
-- **900×1200** — 9.7", iPad Mini
-
-**Apple Vision Pro**
-
-- **3840×2160**
+RocketSim maps each Simulator device to the right App Store Connect output resolution, so you don't have to look it up or resize by hand. Apple can update supported devices and resolution requirements over time, so use [Apple's official app preview specifications](https://help.apple.com/app-store-connect/?lang=en/#/dev4e413fcb8) as the source of truth for the latest supported output resolutions.
 
 ## Drag and drop to App Store Connect
 

--- a/docs/src/content/docs/docs/features/capturing/simulator-camera-support.md
+++ b/docs/src/content/docs/docs/features/capturing/simulator-camera-support.md
@@ -5,7 +5,7 @@ description: "Test camera functionality directly in the iOS Simulator without a 
 
 A top requested feature has always been Simulator camera support. Constantly having to test the camera on an actual device can be a pain and it’s annoying to run into dead ends on the Simulator for apps that come with camera features.
 
-We hear you and we’re excited to share the early beta of RocketSim Camera Simulation.
+RocketSim Camera Simulation lets you test camera flows directly in the Simulator.
 
 Check out these demo’s:
 
@@ -30,7 +30,7 @@ Camera simulation is available from the Capture side window tab:
 
 ## Troubleshooting
 
-Since this is an early version of Camera Simulation, I’m pretty sure you’ll find edge cases that aren’t supported. I’d love to fix these! Could you please:
+If you run into an edge case that isn’t supported yet, I’d love to fix it. Could you please:
 
 1. Add `-com.swiftlee.rocketsim.debug 1` as a launch argument to your app
 2. Relaunch your app and try to get Camera Simulation to work

--- a/docs/src/content/docs/docs/features/networking/network-traffic-monitoring.md
+++ b/docs/src/content/docs/docs/features/networking/network-traffic-monitoring.md
@@ -5,6 +5,10 @@ description: "Monitor HTTP requests and responses from your Simulator app in rea
 
 Powered by RocketSim Connect, you're able to monitor in- and outgoing network requests for your app.
 
+::::tip[Debug networking without leaving the Simulator]
+See live requests, responses, logs, and shareable cURL commands in one place. Historical insights and AI prompt export are included with RocketSim Pro.
+::::
+
 Open the side window and select the **Networking** tab with the antenna icon. RocketSim shows the latest requests inline, and you can click **Open Network Monitor** to inspect the full real-time console.
 
 ![Dedicated Networking tab showing recent network requests and the Open Network Monitor button](./network-traffic-monitoring/side_window_recent_network_requests_monitor.png)

--- a/docs/src/content/docs/docs/features/networking/network-traffic-monitoring.md
+++ b/docs/src/content/docs/docs/features/networking/network-traffic-monitoring.md
@@ -6,7 +6,7 @@ description: "Monitor HTTP requests and responses from your Simulator app in rea
 Powered by RocketSim Connect, you're able to monitor in- and outgoing network requests for your app.
 
 ::::tip[Debug networking without leaving the Simulator]
-See live requests, responses, logs, and shareable cURL commands in one place. Historical insights and AI prompt export are included with RocketSim Pro.
+See live requests, responses, logs, and shareable cURL commands in one place, without proxy certificates or switching tools.
 ::::
 
 Open the side window and select the **Networking** tab with the antenna icon. RocketSim shows the latest requests inline, and you can click **Open Network Monitor** to inspect the full real-time console.

--- a/docs/src/content/pricing/-index.md
+++ b/docs/src/content/pricing/-index.md
@@ -1,9 +1,9 @@
 ---
 title: "Pricing - RocketSim"
 meta_title: "Pricing - RocketSim"
-description: "Choose a pricing plan best suited for you"
+description: "Choose Free or Personal for individual development, or Teams for commercial licensing, seats, billing, and team build insights."
 draft: false
 
 hero:
-  title: "Choose a pricing plan best suited for you"
+  title: "Choose the RocketSim plan for your workflow"
 ---

--- a/docs/src/content/sections/pricing.md
+++ b/docs/src/content/sections/pricing.md
@@ -51,7 +51,7 @@ plans:
       yearly:
         amount: "In-app"
         period: ""
-        note: "Local App Store price shown before purchase"
+        note: "App Store price per country"
     microcopy: "Upgrade in-app when Pro saves you time"
     cta:
       enable: true

--- a/docs/src/content/sections/pricing.md
+++ b/docs/src/content/sections/pricing.md
@@ -49,13 +49,13 @@ plans:
         feature: License management
     price:
       yearly:
-        amount: "Local"
-        period: "App Store price"
+        amount: "App Store price"
+        period: ""
         note: "Shown in-app before purchase"
     microcopy: "Upgrade in-app when Pro saves you time"
     cta:
       enable: true
-      label: Download to view price
+      label: Download now
       site: custom
       link: "https://apps.apple.com/app/apple-store/id1504940162?pt=117264678&ct=pricing-table-personal&mt=8"
       class: "plausible-event-name=App+Store+Install plausible-event-surface=landing plausible-event-placement=landing-pricing-personal plausible-event-format=button"

--- a/docs/src/content/sections/pricing.md
+++ b/docs/src/content/sections/pricing.md
@@ -49,9 +49,9 @@ plans:
         feature: License management
     price:
       yearly:
-        amount: "App Store price"
+        amount: "In-app"
         period: ""
-        note: "Shown in-app before purchase"
+        note: "Local App Store price shown before purchase"
     microcopy: "Upgrade in-app when Pro saves you time"
     cta:
       enable: true

--- a/docs/src/content/sections/pricing.md
+++ b/docs/src/content/sections/pricing.md
@@ -1,10 +1,10 @@
 ---
-title: "Choose a pricing plan best suited <em>for you</em>"
+title: "Choose the RocketSim plan for <em>your workflow</em>"
 
 plans:
   - enable: true
     title: Free
-    description: Explore how our 30+ Xcode Simulator features can increase your productivity
+    description: Start using RocketSim as an individual developer and explore the Simulator workflow improvements.
     price_prefix: "€"
     features:
       - enable: true
@@ -32,8 +32,8 @@ plans:
       class: "plausible-event-name=App+Store+Install plausible-event-surface=landing plausible-event-placement=landing-pricing-free plausible-event-format=button"
   - enable: true
     title: Personal
-    description: Ideal for solo developers—enjoy every Pro feature with an in-app purchase
-    price_prefix: "€"
+    description: For individual developers who want Pro features through the App Store, billed at your local App Store price.
+    price_prefix: ""
     features:
       - enable: true
         included: true
@@ -49,18 +49,19 @@ plans:
         feature: License management
     price:
       yearly:
-        amount: 5
-        period: "/ month"
-    microcopy: "Unlock all Pro features instantly"
+        amount: "Local"
+        period: "App Store price"
+        note: "Shown in-app before purchase"
+    microcopy: "Upgrade in-app when Pro saves you time"
     cta:
       enable: true
-      label: Download now
+      label: Download to view price
       site: custom
       link: "https://apps.apple.com/app/apple-store/id1504940162?pt=117264678&ct=pricing-table-personal&mt=8"
       class: "plausible-event-name=App+Store+Install plausible-event-surface=landing plausible-event-placement=landing-pricing-personal plausible-event-format=button"
   - enable: true
     title: Teams
-    description: Perfect for teams with multiple developers
+    description: For companies that need shared seats, centralized billing, license management, and team build insights.
     price_prefix: "€"
     features:
       - enable: true
@@ -80,7 +81,7 @@ plans:
         amount: 10
         period: "/ seat / month"
         note: "€120 billed annually"
-    microcopy: "No credit card required"
+    microcopy: "Commercial licensing with a 14-day trial"
     cta:
       enable: true
       label: Start 14-day Trial
@@ -89,7 +90,7 @@ plans:
       class: "plausible-event-name=CTA:+Pricing+Teams+-+Trial"
   - enable: true
     title: Enterprise
-    description: For larger enterprise with a need for more control and security
+    description: For larger organizations that need more control, security, and custom distribution.
     price_prefix: ""
     features:
       - enable: true

--- a/docs/src/layouts/components/Feature.astro
+++ b/docs/src/layouts/components/Feature.astro
@@ -16,15 +16,37 @@ const parsedCaption = asset.caption
   ? marked.parseInline(asset.caption)
   : undefined;
 
+async function fetchJson<T>(url: string): Promise<T | undefined> {
+  try {
+    const response = await fetch(url);
+    const contentType = response.headers.get("content-type") ?? "";
+
+    if (!response.ok || !contentType.includes("application/json")) {
+      console.warn(
+        `Skipping WordPress response for "${url}": ${response.status} ${response.statusText} (${contentType || "unknown content type"})`,
+      );
+      return undefined;
+    }
+
+    return (await response.json()) as T;
+  } catch (error) {
+    console.warn(
+      `Skipping WordPress response for "${url}": ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return undefined;
+  }
+}
+
 let blogPath;
 
 if (blogId) {
   const blogBaseUrl = config.blog.base_url;
-  const res = await fetch(
+  const post = await fetchJson<{ slug: string }>(
     `${blogBaseUrl}/wp-json/wp/v2/posts/${blogId}?_fields=slug`,
   );
-  const { slug } = (await res.json()) as { slug: string };
-  blogPath = `/blog/${slug}${blogFragment ? `/#${blogFragment}` : ""}`;
+  blogPath = post
+    ? `/blog/${post.slug}${blogFragment ? `/#${blogFragment}` : ""}`
+    : undefined;
 }
 
 let imageSizes;

--- a/docs/src/layouts/partials/PricingSection.astro
+++ b/docs/src/layouts/partials/PricingSection.astro
@@ -37,12 +37,16 @@ const stripePaymentLink =
             />
           )
         }
-        <p class="text-text text-sm text-center mt-4">
-          Individual developer? Start with{" "}
+        <p class="text-text text-sm text-center mt-4 max-w-2xl mx-auto">
+          Building on your own? Start with{" "}
           <a href="#plan-free" class="text-primary hover:underline"
             >Free or Personal</a
-          >. Working in a team? Check out{" "}
-          <a href="#plan-teams" class="text-primary hover:underline">Teams</a>.
+          >. Personal Pro is purchased in-app at your local App Store price.
+          Buying for a company?{" "}
+          <a href="#plan-teams" class="text-primary hover:underline">Teams</a>{
+            " "
+          }
+          adds seats, shared billing, license management, and team build insights.
         </p>
       </div>
       <div class="section-content">

--- a/docs/src/old/components/InsightsActionable.astro
+++ b/docs/src/old/components/InsightsActionable.astro
@@ -27,7 +27,7 @@ import gaugeAlertIcon from "../../assets/gauge-alert.svg";
     flex-direction: column;
     gap: 1rem;
     padding: 0;
-    margin: 0;
+    margin: 2rem 0 0;
 
     list-style-type: none;
 
@@ -87,8 +87,8 @@ import gaugeAlertIcon from "../../assets/gauge-alert.svg";
         <article data-aos="fade-left" data-aos-delay="300">
           <Image src={gaugeIcon} alt="Speedometer icon" height="20" />
           <p>
-            Save up to 2 hours per month by upgrading Jordi & Hidde's machine to
-            an M3 Max.
+            Save up to 2 hours per month by upgrading older team MacBooks to an
+            M4 Max.
           </p>
         </article>
       </li>
@@ -100,7 +100,7 @@ import gaugeAlertIcon from "../../assets/gauge-alert.svg";
             height="20"
           />
           <p>
-            Antoine is the only one building with Xcode 15.3 which can lead to
+            Antoine is the only one building with Xcode 26.4, which can lead to
             different build results.
           </p>
         </article>
@@ -109,8 +109,8 @@ import gaugeAlertIcon from "../../assets/gauge-alert.svg";
         <article data-aos="fade-left" data-aos-delay="900">
           <Image src={gaugeIcon} alt="Speedometer icon" height="20" />
           <p>
-            Xcode 16.0 seems to improve build times by 10%. Consider upgrading
-            your whole team.
+            Xcode 26.5 is your fastest version so far. Consider upgrading your
+            whole team.
           </p>
         </article>
       </li>

--- a/docs/src/pages/blog/[slug].astro
+++ b/docs/src/pages/blog/[slug].astro
@@ -14,11 +14,52 @@ import { dateFormat } from "@/lib/utils/dateFormat";
 
 const { slug } = Astro.params;
 
+async function fetchJson<T>(url: string): Promise<T | undefined> {
+  try {
+    const response = await fetch(url);
+    const contentType = response.headers.get("content-type") ?? "";
+
+    if (!response.ok || !contentType.includes("application/json")) {
+      console.warn(
+        `Skipping WordPress response for "${url}": ${response.status} ${response.statusText} (${contentType || "unknown content type"})`,
+      );
+      return undefined;
+    }
+
+    return (await response.json()) as T;
+  } catch (error) {
+    console.warn(
+      `Skipping WordPress response for "${url}": ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return undefined;
+  }
+}
+
 export async function getStaticPaths() {
   const blogBaseUrl = config.blog.base_url;
+  const postsUrl = `${blogBaseUrl}/wp-json/wp/v2/posts`;
+  let posts: Array<{ slug: string }> | undefined;
 
-  let data = await fetch(`${blogBaseUrl}/wp-json/wp/v2/posts`);
-  let posts = (await data.json()) as Array<{ slug: string }>;
+  try {
+    const response = await fetch(postsUrl);
+    const contentType = response.headers.get("content-type") ?? "";
+
+    if (!response.ok || !contentType.includes("application/json")) {
+      console.warn(
+        `Skipping WordPress response for "${postsUrl}": ${response.status} ${response.statusText} (${contentType || "unknown content type"})`,
+      );
+    } else {
+      posts = (await response.json()) as Array<{ slug: string }>;
+    }
+  } catch (error) {
+    console.warn(
+      `Skipping WordPress response for "${postsUrl}": ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (!posts) {
+    return [];
+  }
 
   return posts.map((post) => ({
     params: { slug: post.slug },
@@ -31,13 +72,19 @@ let post;
 const blogBaseUrl = config.blog.base_url;
 
 try {
-  const res = await fetch(
+  const posts = await fetchJson<Array<any>>(
     `${blogBaseUrl}/wp-json/wp/v2/posts?slug=${slug}&_embed`,
   );
-  [post] = await res.json();
+  [post] = posts ?? [];
 } catch (e) {
   throw new Error(
     `Failed to fetch blog post for slug "${slug}" from "${blogBaseUrl}/wp-json/wp/v2/posts?slug=${slug}&_embed": ${e instanceof Error ? e.message : String(e)}`,
+  );
+}
+
+if (!post) {
+  throw new Error(
+    `Failed to fetch blog post for slug "${slug}" from "${blogBaseUrl}/wp-json/wp/v2/posts?slug=${slug}&_embed"`,
   );
 }
 

--- a/docs/src/pages/for-teams.astro
+++ b/docs/src/pages/for-teams.astro
@@ -127,7 +127,7 @@ const structuredData = {
   </InsightsBreakdown>
   <InsightsActionable />
   <OnlineTeamManager />
-  <section class="section">
+  <section class="section pt-40">
     <div class="container">
       <div class="section-container">
         <div class="section-intro centralize">

--- a/docs/src/pages/for-teams.astro
+++ b/docs/src/pages/for-teams.astro
@@ -69,19 +69,19 @@ const structuredData = {
       title: "Build Duration by Machine",
       data: [
         {
-          title: "Mac Studio 2024 / M2 Ultra 24-core / 192 RAM",
+          title: 'MacBook Pro 16" / M4 Max 16-core / 128 RAM',
           value: 12,
           width: 0.36,
         },
         {
-          title: 'MacBook Pro 16" 2023 / M3 Max 16-core / 64 RAM',
+          title: 'MacBook Pro 14" / M4 Pro 14-core / 48 RAM',
           value: 14,
           width: 0.42,
         },
         {
-          title: 'MacBook Pro 16" 2021 / M1 Pro 10-core / 32 RAM',
-          value: 26,
-          width: 0.77,
+          title: 'MacBook Pro 16" / M3 Max 16-core / 64 RAM',
+          value: 18,
+          width: 0.54,
         },
       ],
     }}
@@ -94,22 +94,22 @@ const structuredData = {
     </p>
   </InsightsBreakdown>
   <InsightsBreakdown
-    title="Does Xcode 16 improve our project's build times?"
+    title="Does Xcode 26.5 improve our project's build times?"
     chart={{
       title: "Build Duration by Xcode Version",
       data: [
         {
-          title: "Xcode 16.3 (16E140)",
+          title: "Xcode 26.5",
           value: 13.5,
           width: 0.68,
         },
         {
-          title: "Xcode 15.4 (15F31d)",
+          title: "Xcode 26.4",
           value: 15,
           width: 0.76,
         },
         {
-          title: "Xcode 15.3 (15E204a)",
+          title: "Xcode 26.3",
           value: 15.3,
           width: 0.78,
         },

--- a/docs/src/pages/for-teams.astro
+++ b/docs/src/pages/for-teams.astro
@@ -127,6 +127,89 @@ const structuredData = {
   </InsightsBreakdown>
   <InsightsActionable />
   <OnlineTeamManager />
+  <section class="section">
+    <div class="container">
+      <div class="section-container">
+        <div class="section-intro centralize">
+          <h2 class="title hasEmphasize">
+            Give engineering managers build-time answers they can act on
+          </h2>
+          <p class="text-text max-w-3xl mx-auto mt-4">
+            RocketSim for Teams turns local Xcode builds into shared evidence:
+            which machines are fastest, which Xcode versions changed build
+            duration, and where your team is losing time.
+          </p>
+        </div>
+        <div class="grid md:grid-cols-3 gap-6 mt-12">
+          <div class="p-6 rounded-2xl bg-black-accent border border-white/10">
+            <h3 class="h5 mb-3 text-white">Justify hardware upgrades</h3>
+            <p class="text-text">
+              Compare build duration by machine so Mac upgrades are backed by
+              project-specific data instead of guesses.
+            </p>
+          </div>
+          <div class="p-6 rounded-2xl bg-black-accent border border-white/10">
+            <h3 class="h5 mb-3 text-white">Standardize with confidence</h3>
+            <p class="text-text">
+              See how different Xcode, macOS, and SDK versions affect clean and
+              incremental builds before rolling changes out to everyone.
+            </p>
+          </div>
+          <div class="p-6 rounded-2xl bg-black-accent border border-white/10">
+            <h3 class="h5 mb-3 text-white">Skip internal tooling</h3>
+            <p class="text-text">
+              No build phases, no scripts, and no dashboard to maintain.
+              RocketSim syncs build insights quietly in the background.
+            </p>
+          </div>
+        </div>
+        <blockquote
+          class="mt-12 p-8 rounded-2xl bg-primary/10 border border-primary/30"
+        >
+          <p class="text-text-dark text-lg">
+            "RocketSim Team Insights finally gives us visibility into our build
+            times beyond just gut feeling. We can actually measure the impact of
+            adding SDKs or improving configurations, seeing results reflected in
+            incremental and clean builds."
+          </p>
+          <footer class="text-text mt-4">
+            - Max Godfrey, iOS Developer at Tilt
+          </footer>
+        </blockquote>
+        <div class="mt-12 grid md:grid-cols-3 gap-6">
+          <div>
+            <h3 class="h6 mb-2 text-white">Already track builds?</h3>
+            <p class="text-text">
+              RocketSim focuses on local developer build data and setup-free
+              comparisons by project, scheme, machine, and Xcode version.
+            </p>
+          </div>
+          <div>
+            <h3 class="h6 mb-2 text-white">Hard to roll out?</h3>
+            <p class="text-text">
+              Teams use one license key. Developers keep building locally while
+              RocketSim syncs insights in the background.
+            </p>
+          </div>
+          <div>
+            <h3 class="h6 mb-2 text-white">Need to justify another tool?</h3>
+            <p class="text-text">
+              One or two hours saved per developer each month can cover the seat
+              cost while giving managers better decisions.
+            </p>
+          </div>
+        </div>
+        <div class="mt-10 flex justify-center">
+          <a
+            href="https://teams.rocketsim.app/signup/trial"
+            class="btn btn-primary plausible-event-name=CTA:+Team+Page+-+Proof+Start+Trial"
+          >
+            Start 14-Day Trial
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
   <CallToAction />
   <AppStore />
 </Base>


### PR DESCRIPTION
## Summary
- Clarifies Pricing around individual Free/Personal use versus commercial Teams licensing.
- Replaces fixed Personal pricing with local App Store pricing language to avoid country-price confusion.
- Adds value-first Pro callouts to high-intent docs and manager-focused proof/FAQ content for Teams.

## Test plan
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] Opened local preview pages for visual review:
  - `/pricing/`
  - `/for-teams/`
  - `/docs/features/build-insights/team-build-insights/`
  - `/docs/features/accessibility/voiceover-navigator/`
  - `/docs/features/networking/network-traffic-monitoring/`
  - `/docs/features/capturing/app-store-connect-optimization/`
  - `/docs/features/capturing/120-fps-recordings/`