### PR TITLE
Fix SEO issues from crawler report: trailing-slash links, duplicate meta descriptions, duplicate doc titles

### DIFF
--- a/docs/src/components/starlight/PageTitle.astro
+++ b/docs/src/components/starlight/PageTitle.astro
@@ -11,11 +11,11 @@ const isHomepage = id === "docs";
 {
   isHomepage && (
     <div class="homepage-actions">
-      <a href="/docs/getting-started/onboarding" class="action-button primary">
+      <a href="/docs/getting-started/onboarding/" class="action-button primary">
         Get Started →
       </a>
       <a
-        href="/docs/getting-started/product-tour-and-quick-demos"
+        href="/docs/getting-started/product-tour-and-quick-demos/"
         class="action-button secondary"
       >
         Product Tour

--- a/docs/src/components/starlight/SiteTitle.astro
+++ b/docs/src/components/starlight/SiteTitle.astro
@@ -10,7 +10,7 @@ import macAppStoreBadge from "../../assets/mac-app-store-badge.svg";
 ---
 
 <div class="site-title-wrapper sl-flex">
-  <a href="/docs" class="site-title sl-flex" aria-label="RocketSim">
+  <a href="/docs/" class="site-title sl-flex" aria-label="RocketSim">
     <img class="logo-dark" src={logoDark.src} alt="RocketSim" />
     <img class="logo-light" src={logoLight.src} alt="RocketSim" />
   </a>

--- a/docs/src/config/menu.json
+++ b/docs/src/config/menu.json
@@ -2,33 +2,33 @@
   "main": [
     {
       "name": "Features",
-      "url": "/features"
+      "url": "/features/"
     },
     {
       "name": "For Teams",
-      "url": "/for-teams"
+      "url": "/for-teams/"
     },
     {
       "name": "Pricing",
-      "url": "/pricing"
+      "url": "/pricing/"
     },
     {
       "name": "Blog",
-      "url": "/blog"
+      "url": "/blog/"
     },
     {
       "name": "Docs",
-      "url": "https://www.rocketsim.app/docs"
+      "url": "https://www.rocketsim.app/docs/"
     }
   ],
   "support": [
     {
       "name": "Documentation",
-      "url": "/docs"
+      "url": "/docs/"
     },
     {
       "name": "FAQ",
-      "url": "/docs/support/faq"
+      "url": "/docs/support/faq/"
     },
     {
       "name": "Email",
@@ -38,23 +38,23 @@
   "footer": [
     {
       "name": "Features",
-      "url": "/features"
+      "url": "/features/"
     },
     {
       "name": "For Teams",
-      "url": "/for-teams"
+      "url": "/for-teams/"
     },
     {
       "name": "Pricing",
-      "url": "/pricing"
+      "url": "/pricing/"
     },
     {
       "name": "Blog",
-      "url": "/blog"
+      "url": "/blog/"
     },
     {
       "name": "Students",
-      "url": "/student"
+      "url": "/student/"
     }
   ]
 }

--- a/docs/src/content/docs/docs/features/agentic-development/agent-skill.md
+++ b/docs/src/content/docs/docs/features/agentic-development/agent-skill.md
@@ -1,5 +1,5 @@
 ---
-title: "Agent Skill"
+title: "RocketSim Agent Skill"
 description: "Install RocketSim's bundled Agent Skill so AI coding tools can use the version-matched RocketSim CLI safely and reliably."
 sidebar:
   order: 3

--- a/docs/src/content/docs/docs/features/build-insights/xcode-build-optimization-agent-skill.md
+++ b/docs/src/content/docs/docs/features/build-insights/xcode-build-optimization-agent-skill.md
@@ -1,5 +1,5 @@
 ---
-title: "Agent Skill"
+title: "Xcode Build Optimization Agent Skill"
 description: "Use the open-source Xcode Build Optimization Agent Skill alongside RocketSim Build Insights to analyze slow builds, generate optimization plans, and verify improvements over time."
 sidebar:
   order: 3

--- a/docs/src/content/docs/docs/index.mdx
+++ b/docs/src/content/docs/docs/index.mdx
@@ -8,7 +8,7 @@ hero:
   tagline: Guides, resources, and references to help you capture, test, and debug with RocketSim.
   actions:
     - text: Get Started
-      link: /docs/getting-started/onboarding
+      link: /docs/getting-started/onboarding/
     - text: Download RocketSim
       link: https://apps.apple.com/app/apple-store/id1504940162?pt=117264678&ct=docs-landing-hero-button&mt=8
       attrs:
@@ -16,7 +16,7 @@ hero:
         rel: noopener
         class: "hide-below-md plausible-event-name=App+Store+Install plausible-event-surface=docs plausible-event-placement=docs-hero plausible-event-format=button"
     - text: Product Tour
-      link: /docs/getting-started/product-tour-and-quick-demos
+      link: /docs/getting-started/product-tour-and-quick-demos/
       variant: minimal
       icon: right-arrow
 ---
@@ -38,19 +38,19 @@ Get up and running with RocketSim in minutes.
   <FeatureCard
     title="First Steps"
     description="Set up permissions and configure App Actions to start using RocketSim"
-    href="/docs/getting-started/onboarding"
+    href="/docs/getting-started/onboarding/"
     icon="rocket"
   />
   <FeatureCard
     title="Product Tour"
     description="Watch quick demos and explore all of RocketSim's features"
-    href="/docs/getting-started/product-tour-and-quick-demos"
+    href="/docs/getting-started/product-tour-and-quick-demos/"
     icon="circle-play"
   />
   <FeatureCard
     title="Team Usage"
     description="Learn how large teams leverage RocketSim to boost productivity"
-    href="/docs/getting-started/how-large-teams-use-rocketsim"
+    href="/docs/getting-started/how-large-teams-use-rocketsim/"
     icon="users"
   />
 </FeatureGrid>
@@ -63,79 +63,79 @@ Explore RocketSim's powerful suite of tools for iOS development.
   <FeatureCard
     title="RocketSim Connect"
     description="Monitor network traffic and debug API calls in real-time with an intuitive interface"
-    href="/docs/getting-started/setting-up-rocketsim-connect"
+    href="/docs/getting-started/setting-up-rocketsim-connect/"
     icon="plug"
     links={[
       {
         label: "Setup Guide",
-        href: "/docs/getting-started/setting-up-rocketsim-connect",
+        href: "/docs/getting-started/setting-up-rocketsim-connect/",
       },
       {
         label: "Network Monitoring",
-        href: "/docs/features/networking/network-traffic-monitoring",
+        href: "/docs/features/networking/network-traffic-monitoring/",
       },
     ]}
   />
   <FeatureCard
     title="Professional Captures"
     description="Create App Store-ready screenshots with device bezels and high-quality video recordings"
-    href="/docs/features/capturing/screenshots"
+    href="/docs/features/capturing/screenshots/"
     icon="camera"
     links={[
-      { label: "Screenshots", href: "/docs/features/capturing/screenshots" },
-      { label: "Recordings", href: "/docs/features/capturing/recordings" },
+      { label: "Screenshots", href: "/docs/features/capturing/screenshots/" },
+      { label: "Recordings", href: "/docs/features/capturing/recordings/" },
     ]}
   />
   <FeatureCard
     title="Design Comparison"
     description="Achieve pixel-perfect designs with overlays, grids, rulers, and magnifier tools"
-    href="/docs/features/design-comparison/comparing-designs"
+    href="/docs/features/design-comparison/comparing-designs/"
     icon="palette"
     links={[
       {
         label: "Compare Designs",
-        href: "/docs/features/design-comparison/comparing-designs",
+        href: "/docs/features/design-comparison/comparing-designs/",
       },
       {
         label: "Grids & Rulers",
-        href: "/docs/features/design-comparison/grids-and-rulers",
+        href: "/docs/features/design-comparison/grids-and-rulers/",
       },
     ]}
   />
   <FeatureCard
     title="App Actions"
     description="Test push notifications, deep links, location simulation, and network conditions"
-    href="/docs/getting-started/configuring-app-actions"
+    href="/docs/getting-started/configuring-app-actions/"
     icon="zap"
     links={[
       {
         label: "Push Notifications",
-        href: "/docs/features/app-actions/push-notifications",
+        href: "/docs/features/app-actions/push-notifications/",
       },
       {
         label: "Deep Links",
-        href: "/docs/features/app-actions/deeplinks-universal-links",
+        href: "/docs/features/app-actions/deeplinks-universal-links/",
       },
       {
         label: "Location Simulation",
-        href: "/docs/features/app-actions/location-simulation",
+        href: "/docs/features/app-actions/location-simulation/",
       },
     ]}
   />
   <FeatureCard
     title="Accessibility"
     description="Test your app with Dynamic Type and accessibility feature toggles"
-    href="/docs/features/accessibility/toggles-and-dynamic-text"
+    href="/docs/features/accessibility/toggles-and-dynamic-text/"
     icon="accessibility"
   />
   <FeatureCard
     title="Settings"
     description="Customize RocketSim's side window, shortcuts, and interface settings"
-    href="/docs/settings/side-window"
+    href="/docs/settings/side-window/"
     icon="settings"
     links={[
-      { label: "Side Window", href: "/docs/settings/side-window" },
-      { label: "Shortcuts", href: "/docs/settings/shortcuts" },
+      { label: "Side Window", href: "/docs/settings/side-window/" },
+      { label: "Shortcuts", href: "/docs/settings/shortcuts/" },
     ]}
   />
 </FeatureGrid>
@@ -154,19 +154,19 @@ Additional resources to help you make the most of RocketSim.
   <FeatureCard
     title="FAQ"
     description="Find answers to frequently asked questions and common troubleshooting tips"
-    href="/docs/support/faq"
+    href="/docs/support/faq/"
     icon="circle-help"
   />
   <FeatureCard
     title="Support"
     description="Report issues or request new features to help improve RocketSim"
-    href="/docs/support/reporting-an-issue"
+    href="/docs/support/reporting-an-issue/"
     icon="message-circle"
     links={[
-      { label: "Report an Issue", href: "/docs/support/reporting-an-issue" },
+      { label: "Report an Issue", href: "/docs/support/reporting-an-issue/" },
       {
         label: "Request a Feature",
-        href: "/docs/support/requesting-a-feature",
+        href: "/docs/support/requesting-a-feature/",
       },
     ]}
   />

--- a/docs/src/content/privacy/-index.md
+++ b/docs/src/content/privacy/-index.md
@@ -1,6 +1,6 @@
 ---
 title: "Privacy Policy - RocketSim"
 meta_title: "Privacy Policy - RocketSim"
-description: "Simulator Airplane Mode, Location Simulation, Accessibility Testing, Compare designs inside the iOS simulator. Test deeplinks, push notifications."
+description: "Read RocketSim's privacy policy. We collect minimal data, never sell your information, and give you full control over what is stored."
 draft: false
 ---

--- a/docs/src/content/team-insights/-index.md
+++ b/docs/src/content/team-insights/-index.md
@@ -1,6 +1,6 @@
 ---
 title: "RocketSim for Teams - Build Apps Faster with Insights"
 meta_title: "RocketSim for Teams - Build Apps Faster with Insights"
-description: "Simulator Airplane Mode, Location Simulation, Accessibility Testing, Compare designs inside the iOS simulator. Test deeplinks, push notifications."
+description: "Give your whole iOS team shared build insights, machine benchmarks, and simulator tools — all under one license key. See how RocketSim scales across your organization."
 draft: false
 ---

--- a/docs/src/layouts/partials/Footer.astro
+++ b/docs/src/layouts/partials/Footer.astro
@@ -88,12 +88,12 @@ function replaceYear(text: string) {
       />
       <div class="flex flex-col lg:flex-row items-center gap-5">
         <a
-          href="/terms"
+          href="/terms/"
           class="text-text no-underline hover:underline"
           aria-label="Terms and Conditions Link">Terms</a
         >
         <a
-          href="/privacy"
+          href="/privacy/"
           class="text-text no-underline hover:underline"
           aria-label="Privacy Policy Link">Privacy Policy</a
         >

--- a/docs/src/pages/for-teams.astro
+++ b/docs/src/pages/for-teams.astro
@@ -47,7 +47,7 @@ const structuredData = {
   </Header>
   <Navigation showLogin>
     <NavigationLink
-      href="/pricing"
+      href="/pricing/"
       asButton
       className="plausible-event-name=CTA:+Team+Page+-+See+Pricing"
     >

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -59,7 +59,7 @@ const seo = {
       Free download
     </NavigationLink>
     <NavigationLink
-      href="/features"
+      href="/features/"
       className="plausible-event-name=CTA:+Homepage+Hero+-+Features"
       >Explore features &rarr;</NavigationLink
     >


### PR DESCRIPTION
- Add trailing slashes to all internal nav/footer/CTA links in menu.json, Footer.astro,
  index.astro, for-teams.astro, SiteTitle.astro, PageTitle.astro, and docs/index.mdx
  so they match the canonical trailing-slash URLs and avoid 301 redirect hops (#1)
- Write unique meta description for /for-teams/ and /privacy/ to replace the shared
  homepage fallback description (#2)
- Differentiate duplicate "Agent Skill" page titles: rename to
  "Xcode Build Optimization Agent Skill" and "RocketSim Agent Skill" (#3)

https://claude.ai/code/session_013s8sj2hgtN2qDnYNp3asvr