### PR TITLE
Perf: defer third party widgets

### DIFF
--- a/docs/src/layouts/components/Intercom.astro
+++ b/docs/src/layouts/components/Intercom.astro
@@ -7,11 +7,32 @@
 <script is:inline>
   (function () {
     var w = window;
-    var ic = w.Intercom;
-    if (typeof ic === "function") {
-      ic("reattach_activator");
-      ic("update", w.intercomSettings);
-    } else {
+
+    // Already fully loaded on an earlier page — just reattach for this view
+    // (Astro view transitions re-run this inline script on each navigation).
+    if (typeof w.Intercom === "function" && w.__intercomLoaded) {
+      w.Intercom("reattach_activator");
+      w.Intercom("update", w.intercomSettings);
+      return;
+    }
+
+    // Deferred loader already armed on a previous navigation — don't double-arm.
+    if (w.__intercomArmed) return;
+    w.__intercomArmed = true;
+
+    var events = ["scroll", "mousemove", "touchstart", "keydown", "click"];
+
+    function cleanup() {
+      events.forEach(function (e) {
+        w.removeEventListener(e, loadIntercom);
+      });
+    }
+
+    function loadIntercom() {
+      if (w.__intercomLoaded) return;
+      w.__intercomLoaded = true;
+      cleanup();
+
       var d = document;
       var i = function () {
         i.c(arguments);
@@ -21,21 +42,24 @@
         i.q.push(args);
       };
       w.Intercom = i;
-      var l = function () {
-        var s = d.createElement("script");
-        s.type = "text/javascript";
-        s.async = true;
-        s.src = "https://widget.intercom.io/widget/wbadhzkf";
-        var x = d.getElementsByTagName("script")[0];
-        x.parentNode.insertBefore(s, x);
-      };
-      if (document.readyState === "complete") {
-        l();
-      } else if (w.attachEvent) {
-        w.attachEvent("onload", l);
-      } else {
-        w.addEventListener("load", l, false);
-      }
+      var s = d.createElement("script");
+      s.type = "text/javascript";
+      s.async = true;
+      s.src = "https://widget.intercom.io/widget/wbadhzkf";
+      var x = d.getElementsByTagName("script")[0];
+      x.parentNode.insertBefore(s, x);
+    }
+
+    // Load on the first genuine interaction…
+    events.forEach(function (e) {
+      w.addEventListener(e, loadIntercom, { once: true, passive: true });
+    });
+
+    // …with an idle/time fallback so passive readers still get the launcher.
+    if ("requestIdleCallback" in w) {
+      w.requestIdleCallback(loadIntercom, { timeout: 5000 });
+    } else {
+      setTimeout(loadIntercom, 5000);
     }
   })();
 </script>

--- a/docs/src/layouts/components/LazySenja.astro
+++ b/docs/src/layouts/components/LazySenja.astro
@@ -1,0 +1,63 @@
+---
+// Shared lazy-loader for Senja testimonial widgets.
+//
+// Senja is the single heaviest third party on the homepage (~430 KB across
+// ~10 requests, ~1.5 s of JS, plus a render-blocking Google Fonts/Inter
+// request the site does not otherwise use). Both Senja embeds render well
+// below the fold, so there is no reason to fetch anything before the user
+// scrolls near them.
+//
+// Each embed keeps its loader URL on `data-senja-src` and carries the
+// `js-lazy-senja` class instead of shipping an inline `<script src>`. The
+// observer below injects the loader only once the embed approaches the
+// viewport — mirroring the lazy feature-video pattern in
+// `src/layouts/components/Feature.astro`.
+---
+
+<script>
+  // Astro de-duplicates scripts, so this only runs once even when multiple
+  // Senja embeds are present on the page.
+  function setupLazySenja() {
+    const embeds = document.querySelectorAll<HTMLElement>(".js-lazy-senja");
+    if (embeds.length === 0) return;
+
+    // Track injected loader URLs so two embeds sharing the same loader origin
+    // don't add the same script twice.
+    const injected = new Set<string>();
+
+    const loadEmbed = (embed: HTMLElement) => {
+      if (embed.dataset.senjaLoaded === "true") return;
+      const src = embed.dataset.senjaSrc;
+      embed.dataset.senjaLoaded = "true";
+      if (!src || injected.has(src)) return;
+      injected.add(src);
+
+      // Senja's platform script auto-initialises any `.senja-embed` already in
+      // the DOM once it loads, so injecting the loader is enough — no manual
+      // init call is required.
+      const script = document.createElement("script");
+      script.src = src;
+      script.async = true;
+      script.type = "text/javascript";
+      document.body.appendChild(script);
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return;
+          const embed = entry.target as HTMLElement;
+          loadEmbed(embed);
+          observer.unobserve(embed);
+        });
+      },
+      // Start the fetch slightly before the widget is visible so it feels
+      // instant without costing anything on initial load.
+      { threshold: 0, rootMargin: "200px 0px" },
+    );
+
+    embeds.forEach((embed) => observer.observe(embed));
+  }
+
+  document.addEventListener("astro:page-load", setupLazySenja);
+</script>

--- a/docs/src/old/components/Reviews.astro
+++ b/docs/src/old/components/Reviews.astro
@@ -1,5 +1,6 @@
 ---
 // Senja testimonials widget
+import LazySenja from "../../layouts/components/LazySenja.astro";
 ---
 
 <style>
@@ -7,21 +8,30 @@
     margin-top: 5rem;
     margin-bottom: 5rem;
   }
+
+  /* Reserve space so the lazy-loaded widget does not shove content down when
+     it renders (keeps CLS at 0). */
+  .senja-embed {
+    min-height: 520px;
+  }
+
+  @media (max-width: 768px) {
+    .senja-embed {
+      min-height: 900px;
+    }
+  }
 </style>
 
 <section aria-label="Reviews from users">
   <div
-    class="senja-embed"
+    class="senja-embed js-lazy-senja"
     data-id="3e26a85b-fd07-45d2-88b6-a69564850353"
     data-mode="shadow"
     data-lazyload="false"
+    data-senja-src="https://widget.senja.io/widget/3e26a85b-fd07-45d2-88b6-a69564850353/platform.js"
     style="display: block; width: 100%;"
   >
   </div>
 </section>
 
-<script
-  is:inline
-  src="https://widget.senja.io/widget/3e26a85b-fd07-45d2-88b6-a69564850353/platform.js"
-  type="text/javascript"
-  async></script>
+<LazySenja />

--- a/docs/src/old/components/SocialMediaMentions.astro
+++ b/docs/src/old/components/SocialMediaMentions.astro
@@ -1,10 +1,23 @@
 ---
 import SectionHeader from "./SectionHeader.astro";
+import LazySenja from "../../layouts/components/LazySenja.astro";
 ---
 
 <style>
   .mentions {
     margin-top: 3rem;
+  }
+
+  /* Reserve space so the lazy-loaded widget does not shove content down when
+     it renders (keeps CLS at 0). */
+  .senja-embed {
+    min-height: 600px;
+  }
+
+  @media (max-width: 768px) {
+    .senja-embed {
+      min-height: 1000px;
+    }
   }
 </style>
 
@@ -18,13 +31,14 @@ import SectionHeader from "./SectionHeader.astro";
   </div>
   <div class="deprecated-grid mentions">
     <div
-      class="senja-embed"
+      class="senja-embed js-lazy-senja"
       data-id="7b8ef1aa-201a-401a-a9d3-99fdf5325311"
       data-lazyload="true"
       data-mode="shadow"
+      data-senja-src="https://static.senja.io/dist/platform.js"
     >
     </div>
-    <script is:inline async src="https://static.senja.io/dist/platform.js"
-    ></script>
   </div>
 </section>
+
+<LazySenja />


### PR DESCRIPTION
## Why

Antoine reported the landing page *felt* slow — usable only once the Intercom bubble appeared. That's the tell: the page looks done fast but stays unresponsive while third-party scripts fire on `window.load`.

## Findings (Lighthouse, mobile/throttled)

Page content is healthy; third-party is the cost. **Speed Index 2.1 s but TTI 11.7 s** — the "looks done but isn't" gap.

- **Senja** (testimonials): heaviest third party — ~430 KB, ~1.5 s JS, plus render-blocking Google Fonts. Renders below the fold but fetched eagerly on parse.
- **Intercom**: ~344 KB JS, a long task still running ~13 s in. Loaded on `window.load` — the worst moment for interactivity.

## Solution

- **Lazy-load Senja** (`fec0cdf`): inject loaders via a shared `IntersectionObserver` (200px margin) only as widgets near the viewport; reserve `min-height` so CLS stays ~0.
- **Defer Intercom** (`ac0d33a`): replace the `window.load` trigger with first-interaction + a `requestIdleCallback` idle fallback (5 s backstop). Passive readers still get the launcher via idle; window-level guards prevent double-loading across view transitions.

## Verification

- A/B test in headless Chrome: old code fired Intercom on load, new code fires nothing until interaction/idle.
- Senja: zero `senja.io` / Google-Fonts requests on initial load; CLS ~0.
- `build`, `lint`, `format:check`, `typecheck`, `knip` all pass.

> Intercom returns 403 on `localhost` (untrusted domain) — expected, unrelated; launcher rendering is verifiable only on production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)