### PR TITLE
Make Device Hub intro version-only

### DIFF
--- a/docs/src/content/docs/docs/features/capturing/device-hub-support.md
+++ b/docs/src/content/docs/docs/features/capturing/device-hub-support.md
@@ -5,7 +5,7 @@ sidebar:
   order: 4
 ---
 
-Device Hub is the new app introduced with **Xcode 27** at WWDC. It brings Simulators and connected devices together in a single window, replacing the standalone Simulator window you used in earlier Xcode versions. RocketSim adds first-class support for Device Hub, so the workflows you already rely on keep working alongside it.
+Device Hub is the new app introduced in **Xcode 27**. It brings Simulators and connected devices together in a single window, replacing the standalone Simulator window you used in earlier Xcode versions. RocketSim adds first-class support for Device Hub, so the workflows you already rely on keep working alongside it.
 
 ![RocketSim's side window showing the VoiceOver Navigator next to an iPhone running inside Xcode 27's Device Hub](./device-hub-support/voiceover-navigator.png)
 


### PR DESCRIPTION
## Summary
- Follow-up to #1049. Drops the "at WWDC" reference from the Device Hub Support doc intro so the page stays accurate over time (version-only phrasing).
- Addresses Copilot review feedback on #1049.

Note: Copilot also suggested adding the "Compact Mode" caveat to the homepage hero microcopy. I intentionally left that out — it's one-line marketing copy above the fold, the compatibility claim is accurate, and the Compact Mode detail is already documented on the Device Hub Support page.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run knip`