### PR TITLE
Docs: CLI capture commands + snapshot canvasSize

### DIFF
--- a/docs/src/content/docs/docs/features/agentic-development/index.md
+++ b/docs/src/content/docs/docs/features/agentic-development/index.md
@@ -84,7 +84,7 @@ RocketSim ships the CLI and Agent Skill inside the app. When RocketSim updates, 
 RocketSim's agentic development support has three layers:
 
 1. **The RocketSim Mac app** keeps the live Simulator connection, caches state, and performs the optimized work.
-2. **The RocketSim CLI** exposes that running app to agents through commands such as `elements`, `interact`, `wait`, `screenshot`, and `doctor`.
+2. **The RocketSim CLI** exposes that running app to agents through commands such as `elements`, `interact`, `wait`, `screenshot`, `video record`, and `doctor`.
 3. **The RocketSim Agent Skill** teaches your AI coding tool how to use the CLI safely and consistently.
 
 Install both the command line tool and Agent Skill from **RocketSim → Settings → CLI & Agent**. RocketSim creates symlinks into your chosen folders, so the CLI and skill keep pointing at the latest installed app.

--- a/docs/src/content/docs/docs/features/agentic-development/rocketsim-cli.md
+++ b/docs/src/content/docs/docs/features/agentic-development/rocketsim-cli.md
@@ -86,7 +86,9 @@ rocketsim snapshot
 
 These commands are optimized for agent workflows and help agents reason about whether the screen changed after an interaction.
 
-### Screenshot fallback
+The JSON snapshot also includes `data.canvasSize` (`[width, height]` in device points), which describes the full screen the elements were laid out in. This is the union of every raw accessibility frame, including the full-screen application root, so it spans the true device bounds rather than just the box around the visible content. Use it to scale element frames onto a rendered screenshot or overlay without re-deriving the device size, which is especially important on scrollable screens where the visible content does not fill the screen.
+
+### Screenshots
 
 When accessibility data is not enough, agents can request a plain PNG screenshot:
 
@@ -94,7 +96,58 @@ When accessibility data is not enough, agents can request a plain PNG screenshot
 rocketsim screenshot > screen.png
 ```
 
-This is useful for visual fallback flows, sparse web content, or debugging what the agent sees.
+This is useful for visual fallback flows, sparse web content, or debugging what the agent sees. The raw PNG bytes are written to stdout, so redirect them to a file. Target a specific simulator with `--udid <udid>` instead of the focused one.
+
+Screenshots can also be styled with the same options RocketSim uses for its capturing tools:
+
+```bash
+rocketsim screenshot \
+  --bezel simulator \
+  --background "#0B1221" \
+  --device-shadow \
+  --ratio 16:9 > styled.png
+```
+
+| Option | Description |
+| --- | --- |
+| `--background <value>` | Background color: `transparent`, a preset color, or `#RRGGBB`. |
+| `--bezel <style>` | Device frame style: `none`, `simulator`, or `device`. |
+| `--frame-color <value>` | Device frame tint as a preset color or `#RRGGBB`. |
+| `--device-shadow` | Render a shadow behind the device frame. |
+| `--ratio <ratio>` | Output ratio: `auto`, `1:1`, `5:4`, `4:3`, `3:2`, or `16:9`. |
+| `--asc` | Optimize output dimensions for App Store Connect. |
+| `--watermark` | Render the RocketSim watermark. |
+| `--metadata` | Render app metadata when available and supported by the selected ratio. |
+| `--touches` | Render captured touches. |
+| `--touch-color <value>` | Touch color as a preset color or `#RRGGBB`. |
+| `--touch-stroke` | Render a stroke around touches. |
+| `--orientation <value>` | Output orientation: `portrait`, `portraitUpsideDown`, `landscapeLeft`, or `landscapeRight`. |
+
+To preview the capture in RocketSim's [floating thumbnail](/docs/features/capturing/floating-thumbnail) instead of writing bytes to stdout, add `--show-floating-thumbnail`:
+
+```bash
+rocketsim screenshot --show-floating-thumbnail
+```
+
+### Video recordings
+
+Agents and scripts can record the simulator to an MP4. Recording continues until you press `Ctrl+C`, at which point RocketSim finalizes the file and writes the bytes to stdout:
+
+```bash
+rocketsim video record > recording.mp4
+```
+
+Press `Ctrl+C` to stop the recording and flush the MP4. Target a specific simulator with `--udid <udid>` and set the frame rate with `--fps <value>` (between 1 and 120, default 30):
+
+```bash
+rocketsim video record --fps 60 --udid <udid> > recording.mp4
+```
+
+`video record` accepts the same styling options as `screenshot` (see the table above), so you can record framed, touch-annotated, or App Store Connect–optimized clips. As with screenshots, add `--show-floating-thumbnail` to send the finished recording to RocketSim's floating thumbnail instead of stdout:
+
+```bash
+rocketsim video record --bezel device --touches --show-floating-thumbnail
+```
 
 ### Waiting for UI changes
 

--- a/docs/src/content/docs/docs/features/agentic-development/rocketsim-cli.md
+++ b/docs/src/content/docs/docs/features/agentic-development/rocketsim-cli.md
@@ -108,19 +108,19 @@ rocketsim screenshot \
   --ratio 16:9 > styled.png
 ```
 
-| Option | Description |
-| --- | --- |
-| `--background <value>` | Background color: `transparent`, a preset color, or `#RRGGBB`. |
-| `--bezel <style>` | Device frame style: `none`, `simulator`, or `device`. |
-| `--frame-color <value>` | Device frame tint as a preset color or `#RRGGBB`. |
-| `--device-shadow` | Render a shadow behind the device frame. |
-| `--ratio <ratio>` | Output ratio: `auto`, `1:1`, `5:4`, `4:3`, `3:2`, or `16:9`. |
-| `--asc` | Optimize output dimensions for App Store Connect. |
-| `--watermark` | Render the RocketSim watermark. |
-| `--metadata` | Render app metadata when available and supported by the selected ratio. |
-| `--touches` | Render captured touches. |
-| `--touch-color <value>` | Touch color as a preset color or `#RRGGBB`. |
-| `--touch-stroke` | Render a stroke around touches. |
+| Option                  | Description                                                                                 |
+| ----------------------- | ------------------------------------------------------------------------------------------- |
+| `--background <value>`  | Background color: `transparent`, a preset color, or `#RRGGBB`.                              |
+| `--bezel <style>`       | Device frame style: `none`, `simulator`, or `device`.                                       |
+| `--frame-color <value>` | Device frame tint as a preset color or `#RRGGBB`.                                           |
+| `--device-shadow`       | Render a shadow behind the device frame.                                                    |
+| `--ratio <ratio>`       | Output ratio: `auto`, `1:1`, `5:4`, `4:3`, `3:2`, or `16:9`.                                |
+| `--asc`                 | Optimize output dimensions for App Store Connect.                                           |
+| `--watermark`           | Render the RocketSim watermark.                                                             |
+| `--metadata`            | Render app metadata when available and supported by the selected ratio.                     |
+| `--touches`             | Render captured touches.                                                                    |
+| `--touch-color <value>` | Touch color as a preset color or `#RRGGBB`.                                                 |
+| `--touch-stroke`        | Render a stroke around touches.                                                             |
 | `--orientation <value>` | Output orientation: `portrait`, `portraitUpsideDown`, `landscapeLeft`, or `landscapeRight`. |
 
 To preview the capture in RocketSim's [floating thumbnail](/docs/features/capturing/floating-thumbnail) instead of writing bytes to stdout, add `--show-floating-thumbnail`:


### PR DESCRIPTION
## Summary
Documents the agent-facing CLI surface that recently shipped in RocketSim, keeping the canonical docs in sync with the app and bundled skill.

- **`screenshot`**: document `--udid`, the shared capture styling options (`--background`, `--bezel`, `--frame-color`, `--device-shadow`, `--ratio`/`--asc`, `--watermark`, `--metadata`, `--touches`/`--touch-color`/`--touch-stroke`, `--orientation`) as a table, plus `--show-floating-thumbnail`.
- **`video record`**: new section covering `rocketsim video record > recording.mp4`, `--fps` (1–120, default 30), Ctrl+C to stop/flush, the shared capture styling options, and `--show-floating-thumbnail`.
- **`data.canvasSize`**: document the new JSON snapshot field (`[width, height]` device points = union of all raw frames incl. the app root) and why it matters for scaling element frames onto a rendered screen/overlay.
- Add `video record` to the command list in the agentic-development overview.

## Related
- Pairs with RocketSim PR #1171 (adds `canvasSize` to the agent snapshot / CLI output).
- Covers the CLI capture work already merged into RocketSim (screenshot/video commands + floating thumbnail).

## Test plan
- [x] `npm run build` (astro build) succeeds — 78 pages built, no new errors.
- [x] Internal `floating-thumbnail` link uses the same slug as the rest of the docs.