### PR TITLE
Fix mobile install intent tracking

### DIFF
--- a/docs/src/old/components/MobileDownloadLinkForm.astro
+++ b/docs/src/old/components/MobileDownloadLinkForm.astro
@@ -286,6 +286,7 @@ import appIcon from "../../assets/rocketsim-app-icon.png";
       "[data-mobile-download-app-store]",
     );
     const storageKey = "rocketsim-mobile-download-dismissed";
+    const mobileDownloadKitFormId = "9491475";
     let hasTrackedView = false;
     let hasLoadedKit = false;
     let hasTrackedEmailFocus = false;
@@ -326,7 +327,7 @@ import appIcon from "../../assets/rocketsim-app-icon.png";
       return props;
     };
 
-    const propsFromLink = (link?: HTMLAnchorElement) =>
+    const propsFromLink = (link?: HTMLAnchorElement): Record<string, string> =>
       link ? getPlausibleProps(link) : {};
 
     const getMobilePromptProps = (link?: HTMLAnchorElement) => {
@@ -406,7 +407,12 @@ import appIcon from "../../assets/rocketsim-app-icon.png";
     });
 
     appStoreLink?.addEventListener("click", () => {
-      track("Mobile Download App Store Link Clicked", getMobilePromptProps());
+      const link =
+        appStoreLink instanceof HTMLAnchorElement ? appStoreLink : undefined;
+      track(
+        "Mobile Download App Store Link Clicked",
+        getMobilePromptProps(link),
+      );
       sessionStorage.setItem(storageKey, "1");
       hideIntentPrompt();
     });
@@ -454,7 +460,8 @@ import appIcon from "../../assets/rocketsim-app-icon.png";
         if (!(form instanceof HTMLFormElement)) return;
         const isMobileDownloadForm =
           formContainer?.contains(form) ||
-          (!container.hidden && form.dataset.svForm === "9491475");
+          (!container.hidden &&
+            form.dataset.svForm === mobileDownloadKitFormId);
         if (!isMobileDownloadForm) return;
 
         track("Mobile Download Link Form Submitted", getMobilePromptProps());

--- a/docs/src/old/components/MobileDownloadLinkForm.astro
+++ b/docs/src/old/components/MobileDownloadLinkForm.astro
@@ -326,6 +326,21 @@ import appIcon from "../../assets/rocketsim-app-icon.png";
       return props;
     };
 
+    const propsFromLink = (link?: HTMLAnchorElement) =>
+      link ? getPlausibleProps(link) : {};
+
+    const getMobilePromptProps = (link?: HTMLAnchorElement) => {
+      const props = propsFromLink(link);
+
+      return {
+        ...props,
+        surface: props.surface || "mobile-download",
+        placement: props.placement || "intent-prompt",
+        format: props.format || "prompt",
+        source: "mobile-install-intent",
+      };
+    };
+
     const loadKitForm = () => {
       if (hasLoadedKit || !formContainer) return;
 
@@ -351,7 +366,12 @@ import appIcon from "../../assets/rocketsim-app-icon.png";
       openButton?.setAttribute("aria-expanded", "true");
       loadKitForm();
 
-      const props = getPlausibleProps(sourceLink);
+      const props = getMobilePromptProps(sourceLink);
+
+      // Preserve the primary install-click KPI even though the mobile prompt
+      // intercepts the original App Store link before Plausible's class-based
+      // click handler can observe it.
+      track("App Store Install", props);
       track("Mobile Download App Store Clicked", props);
 
       if (!hasTrackedView) {
@@ -386,7 +406,7 @@ import appIcon from "../../assets/rocketsim-app-icon.png";
     });
 
     appStoreLink?.addEventListener("click", () => {
-      track("Mobile Download App Store Link Clicked");
+      track("Mobile Download App Store Link Clicked", getMobilePromptProps());
       sessionStorage.setItem(storageKey, "1");
       hideIntentPrompt();
     });
@@ -422,7 +442,7 @@ import appIcon from "../../assets/rocketsim-app-icon.png";
         if (!target.matches("input, textarea")) return;
 
         hasTrackedEmailFocus = true;
-        track("Mobile Download Email Field Focused");
+        track("Mobile Download Email Field Focused", getMobilePromptProps());
       },
       true,
     );
@@ -432,9 +452,12 @@ import appIcon from "../../assets/rocketsim-app-icon.png";
       (event) => {
         const form = event.target;
         if (!(form instanceof HTMLFormElement)) return;
-        if (!formContainer?.contains(form)) return;
+        const isMobileDownloadForm =
+          formContainer?.contains(form) ||
+          (!container.hidden && form.dataset.svForm === "9491475");
+        if (!isMobileDownloadForm) return;
 
-        track("Mobile Download Link Form Submitted");
+        track("Mobile Download Link Form Submitted", getMobilePromptProps());
         sessionStorage.setItem(storageKey, "1");
         hideIntentPrompt();
       },


### PR DESCRIPTION
## Summary
- Preserve `App Store Install` tracking when the mobile intent prompt intercepts an App Store click before Plausible's class-based handler can observe it.
- Add stable mobile prompt properties to the prompt funnel events so they carry consistent source/surface/placement metadata.
- Loosen the Kit submit guard enough to still catch the mobile form if ConvertKit dispatches outside the injected container while the prompt is visible.

## Test plan
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm run knip