### PR TITLE
Document Enterprise Build Insights privacy controls

### DIFF
--- a/docs/src/content/docs/docs/features/build-insights/team-build-insights.md
+++ b/docs/src/content/docs/docs/features/build-insights/team-build-insights.md
@@ -19,6 +19,8 @@ RocketSim silently syncs build data in the background. It syncs at most once per
 
 Team Build Insights requires a Pro subscription with a team license key. Once configured, data flows automatically.
 
+Enterprise teams can turn Build Insights syncing off from the Teams portal. When disabled, RocketSim keeps Build Insights data local to the Mac and stops sending project names, scheme names, build durations, workspace lookups, and related Build Insights machine metadata to RocketSim Services. License activation and validation still use RocketSim Services so seats remain protected.
+
 :::tip[For engineering managers]
 Use Team Build Insights when you need evidence for hardware upgrades, Xcode rollouts, or SDK changes. RocketSim gives you project-specific build data without adding build phases or maintaining internal scripts.
 :::

--- a/docs/src/content/privacy/-index.md
+++ b/docs/src/content/privacy/-index.md
@@ -1,6 +1,6 @@
 ---
 title: "Privacy Policy - RocketSim"
 meta_title: "Privacy Policy - RocketSim"
-description: "Read RocketSim's privacy policy. We collect minimal data, never sell your information, and give you full control over what is stored."
+description: "Read RocketSim's privacy policy. We collect minimal data, never sell your information, and Enterprise teams can disable Build Insights syncing."
 draft: false
 ---

--- a/docs/src/content/sections/compare-plans.md
+++ b/docs/src/content/sections/compare-plans.md
@@ -325,6 +325,10 @@ compare_plans:
           free: false
           individual: false
           teams: true
+        - item: Admin-controlled local-only Build Insights mode
+          free: false
+          individual: false
+          teams: Enterprise
     - title: Team manager
       list:
         - item: License management

--- a/docs/src/content/sections/compare-plans.md
+++ b/docs/src/content/sections/compare-plans.md
@@ -325,10 +325,10 @@ compare_plans:
           free: false
           individual: false
           teams: true
-        - item: Admin-controlled local-only Build Insights mode
+        - item: Local-only mode by disabling build data syncing (extra privacy)
           free: false
           individual: false
-          teams: Enterprise
+          teams: true
     - title: Team manager
       list:
         - item: License management

--- a/docs/src/content/sections/faq.md
+++ b/docs/src/content/sections/faq.md
@@ -17,4 +17,7 @@ list:
   - enable: true
     question: "Can I download RocketSim outside of the Mac App Store?"
     answer: "Yes, with our enterprise plan, RocketSim can be downloaded and distributed outside of the Mac App Store. **[Contact sales](mailto:ralphduin@rocketsim.app) for details.**"
+  - enable: true
+    question: "Can we disable Build Insights syncing for security reviews?"
+    answer: "Yes. Enterprise teams can disable Build Insights syncing from the Teams portal, so project names, schemes, build durations, workspace lookups, and related Build Insights metadata stay local to the Mac app. RocketSim still communicates with RocketSim Services for license activation and validation."
 ---

--- a/docs/src/content/sections/pricing.md
+++ b/docs/src/content/sections/pricing.md
@@ -71,6 +71,9 @@ plans:
         included: true
         feature: Team build insights
       - enable: true
+        included: false
+        feature: "Local-only Build Insights mode (Enterprise)"
+      - enable: true
         included: true
         feature: User management
       - enable: true
@@ -81,7 +84,7 @@ plans:
         amount: 10
         period: "/ seat / month"
         note: "€120 billed annually"
-    microcopy: "Commercial licensing with a 14-day trial"
+    microcopy: "Need RocketSim to pass stricter security reviews? Enterprise can turn Build Insights syncing off so build data stays local. [Get in touch](mailto:antoine@rocketsim.app)"
     cta:
       enable: true
       label: Start 14-day Trial
@@ -105,6 +108,9 @@ plans:
       - enable: true
         included: true
         feature: Group based user management
+      - enable: true
+        included: true
+        feature: "Local-only Build Insights mode controlled from the Teams portal"
     price:
       yearly:
         amount: "Custom"

--- a/docs/src/content/sections/pricing.md
+++ b/docs/src/content/sections/pricing.md
@@ -84,7 +84,7 @@ plans:
         amount: 10
         period: "/ seat / month"
         note: "€120 billed annually"
-    microcopy: "Need RocketSim to pass stricter security reviews? Enterprise can turn Build Insights syncing off so build data stays local. [Get in touch](mailto:antoine@rocketsim.app)"
+    microcopy: "Commercial licensing with a 14-day trial"
     cta:
       enable: true
       label: Start 14-day Trial

--- a/docs/src/pages/privacy.astro
+++ b/docs/src/pages/privacy.astro
@@ -69,7 +69,7 @@ const seo = {
       <section>
         <p>
           <em
-            >This privacy statement was most recently revised on 28 April 2026</em
+            >This privacy statement was most recently revised on 18 June 2026</em
           >
         </p>
         <p>
@@ -206,6 +206,14 @@ const seo = {
           <strong>Retention period:</strong><br />During the subscription term,
           data will be retained. Upon termination of the subscription, all data
           will be permanently deleted within 30 days.
+        </p>
+        <p>
+          Enterprise customers can disable Build Insights syncing from the Teams
+          portal. When disabled, RocketSim no longer sends project names, scheme
+          names, build durations, workspace lookups, or related machine metadata
+          to RocketSim Services for Build Insights, turning the Mac app into a
+          local-only app for that data. License activation and validation
+          continue to communicate with RocketSim Services.
         </p>
       </section>
       <section aria-labelledby="use-of-services">


### PR DESCRIPTION
## Summary
- Update the privacy policy to describe Enterprise-controlled Build Insights local-only mode.
- Add Enterprise local-only Build Insights positioning to pricing, comparison, and FAQ copy.
- Document what stops syncing and what remains required for license activation/validation.

## Test plan
- `npm run typecheck`
- `npm run format:check`