### PR TITLE
Refine SEO positioning for product docs

### DIFF
--- a/docs/src/collections/feature-page/agentic-development.md
+++ b/docs/src/collections/feature-page/agentic-development.md
@@ -1,7 +1,7 @@
 ---
-title: "Agentic Development"
-description: "Let AI coding agents inspect and interact with your running iOS Simulator app through RocketSim's version-matched CLI and Agent Skill."
+title: "Agentic iOS Simulator Development"
+description: "Let Cursor, Claude, Codex, Xcode, and other AI coding agents inspect, navigate, and verify your running iOS Simulator app."
 hero:
-  title: "Agentic Development"
-  subtitle: "A token-efficient Simulator control layer for AI coding agents"
+  title: "Agentic iOS Simulator Development"
+  subtitle: "A token-efficient Simulator navigation layer for AI coding agents"
 ---

--- a/docs/src/collections/feature-page/networking.md
+++ b/docs/src/collections/feature-page/networking.md
@@ -1,7 +1,7 @@
 ---
 title: "Networking"
-description: "Monitor network requests in realtime, correlate them with app logs, export prompt-ready debugging context, control network speed, and simulate airplane mode."
+description: "Monitor URLSession requests without proxy certificates, export AI-ready debugging prompts, control network speed, and simulate airplane mode."
 hero:
   title: "Networking"
-  subtitle: "Inspect requests, correlate app logs, export debugging context, and control your app's network traffic"
+  subtitle: "Inspect requests, export AI-ready debugging context, and control Simulator network conditions"
 ---

--- a/docs/src/content/docs/docs/features/agentic-development/agent-skill.md
+++ b/docs/src/content/docs/docs/features/agentic-development/agent-skill.md
@@ -1,17 +1,19 @@
 ---
 title: "RocketSim Agent Skill"
-description: "Install RocketSim's bundled Agent Skill so AI coding tools can use the version-matched RocketSim CLI safely and reliably."
+description: "Install RocketSim's bundled Agent Skill so Cursor, Claude, Codex, Xcode, and other AI coding tools can navigate the iOS Simulator safely."
 sidebar:
   order: 3
 ---
 
-The RocketSim Agent Skill is the recommended way to connect AI coding tools to RocketSim. It teaches your agent how to use the version-matched `rocketsim` CLI, when to read elements, when to interact, how to recover after screen changes, and when to use a screenshot fallback.
+The RocketSim Agent Skill is the recommended way to connect AI coding tools to RocketSim. It teaches your agent how to use the version-matched `rocketsim` CLI, when to read visible elements, when to interact, how to recover after screen changes, and when to use a screenshot fallback.
 
 Install it from **RocketSim → Settings → CLI & Agent**.
 
 ## Why the skill is recommended
 
 You can run the CLI yourself, but agents perform best when they have clear, tool-specific instructions. The RocketSim Agent Skill provides those instructions without requiring you to copy prompts into every project.
+
+Use the skill when you want Cursor, Claude, Codex, Xcode, or another coding agent to inspect a running Simulator app and perform real UI steps. The skill keeps the agent focused on RocketSim's safest interaction loop instead of inventing shell commands or guessing coordinates from screenshots.
 
 The skill helps agents:
 
@@ -79,6 +81,6 @@ If the skill is installed, RocketSim is running, and your app is already open in
 
 ## Learn more
 
-- [RocketSim CLI](/docs/features/agentic-development/rocketsim-cli) -- the commands agents use to inspect and interact with the Simulator
-- [Agentic Development with RocketSim](/docs/features/agentic-development/) -- scenarios, example prompts, and why RocketSim is effective for agent-driven Simulator automation
-- [CLI & Agent settings](/docs/settings/cli-and-agent) -- installing and repairing the CLI and skill
+- [RocketSim CLI](/docs/features/agentic-development/rocketsim-cli) — the commands agents use to inspect and interact with the Simulator
+- [Agentic Development with RocketSim](/docs/features/agentic-development/) — scenarios, example prompts, and why RocketSim is effective for agent-driven Simulator automation
+- [CLI & Agent settings](/docs/settings/cli-and-agent) — installing and repairing the CLI and skill

--- a/docs/src/content/docs/docs/features/agentic-development/index.md
+++ b/docs/src/content/docs/docs/features/agentic-development/index.md
@@ -1,11 +1,11 @@
 ---
 title: "Agentic Development with RocketSim"
-description: "Let AI coding agents see and interact with your running iOS Simulator app through RocketSim's version-matched CLI and Agent Skill."
+description: "Let AI coding agents inspect, navigate, and verify your running iOS Simulator app through RocketSim's version-matched CLI and Agent Skill."
 sidebar:
   order: 1
 ---
 
-RocketSim helps AI coding agents see and interact with your running Simulator app. The RocketSim Mac app stays connected to the Simulator, keeps useful state warm, and exposes a compact CLI that agents can use to inspect screens, tap controls, type text, and verify UI changes.
+RocketSim helps AI coding agents inspect, navigate, and verify your running iOS Simulator app. The RocketSim Mac app stays connected to the Simulator, keeps useful state warm, and exposes a compact CLI that agents can use to read visible elements, tap controls, type text, capture screenshots, and confirm UI changes.
 
 RocketSim does not build, install, or launch your app from source. Start the app with Xcode or your normal build tooling first, then use RocketSim for fast Simulator inspection and interaction.
 
@@ -24,6 +24,8 @@ Agentic development with RocketSim is useful whenever you want an agent to work 
 ### Navigate and test app flows
 
 Ask your agent to move through multi-step flows like onboarding, login, settings, or purchase screens. RocketSim gives the agent a way to see what is on screen and interact with it step by step.
+
+Instead of relying only on screenshots or brittle coordinate taps, the agent can read accessibility elements and use semantic interactions whenever possible. That makes the loop much closer to how a developer would inspect the same screen manually.
 
 ### Validate UI after code changes
 
@@ -89,8 +91,10 @@ RocketSim's agentic development support has three layers:
 
 Install both the command line tool and Agent Skill from **RocketSim → Settings → CLI & Agent**. RocketSim creates symlinks into your chosen folders, so the CLI and skill keep pointing at the latest installed app.
 
+For most AI coding tools, install the [RocketSim Agent Skill](/docs/features/agentic-development/agent-skill) as well. The skill teaches your agent when to read elements, when to wait, when to interact semantically, and when to fall back to a screenshot.
+
 ## Learn more
 
-- [RocketSim CLI](/docs/features/agentic-development/rocketsim-cli) -- how agents inspect and interact with the Simulator
-- [Agent Skill](/docs/features/agentic-development/agent-skill) -- how to install the recommended agent workflow
-- [CLI & Agent settings](/docs/settings/cli-and-agent) -- how to install the CLI and skill from RocketSim
+- [RocketSim CLI](/docs/features/agentic-development/rocketsim-cli) — how agents inspect and interact with the Simulator
+- [Agent Skill](/docs/features/agentic-development/agent-skill) — how to install the recommended agent workflow
+- [CLI & Agent settings](/docs/settings/cli-and-agent) — how to install the CLI and skill from RocketSim

--- a/docs/src/content/docs/docs/features/capturing/simulator-camera-support.md
+++ b/docs/src/content/docs/docs/features/capturing/simulator-camera-support.md
@@ -1,13 +1,13 @@
 ---
-title: "Simulator Camera Support"
+title: "iOS Simulator Camera Support"
 description: "Test camera functionality directly in the iOS Simulator without a physical device. Stream images or video to the Simulator camera via RocketSim Connect."
 ---
 
-A top requested feature has always been Simulator camera support. Constantly having to test the camera on an actual device can be a pain and it’s annoying to run into dead ends on the Simulator for apps that come with camera features.
+Testing camera flows on the iOS Simulator usually ends with a fallback screen, since the Simulator does not expose a real camera like a physical device. That makes every QR scanner, document scanner, profile photo picker, or video capture flow slower to validate.
 
-RocketSim Camera Simulation lets you test camera flows directly in the Simulator.
+RocketSim Camera Simulation lets you stream images or video into your running Simulator app through RocketSim Connect. You can keep your normal Simulator workflow and test camera-dependent UI without repeatedly deploying to an iPhone.
 
-Check out these demo’s:
+Check out these demos:
 
 - [Glimpsify open-source project demo video](https://x.com/twannl/status/1935303234714792340)
 - [Vision object detection demo video](https://x.com/twannl/status/1926715711277203563)
@@ -19,7 +19,7 @@ Camera simulation is available from the Capture side window tab:
 
 1. Open the Simulator
 2. Navigate to the bottom of the capturing side window
-3. Setup camera authorization via RocketSim’s Side Window
+3. Set up camera authorization via RocketSim's side window
 
    ![The side window in its state after camera permissions have been granted.](./simulator-camera-support/simulator_camera.png)
 
@@ -53,11 +53,11 @@ If you run into an edge case that isn’t supported yet, I’d love to fix it. C
 6. Hit send!
 7. (Optional) if you can share me an Xcode project with your camera code in it, I’ll be able to fix your specific case much quicker
 
-That email will give me all I need to dive deeper into your specific issue
+That email will give me all I need to dive deeper into your specific issue.
 
 ## Known issues
 
 - The macOS camera resolution is used as the resolution of returned sample buffers. This means your captures won’t have the resolution of the original (Simulator) device camera.
-- Video’s do not contain any audio
+- Videos do not contain any audio
 - Switching camera from `front` to `back` does nothing since there’s only one camera available
 - `DataScannerViewController` does not yet work (see [this issue](https://github.com/AvdLee/RocketSimApp/issues/769))

--- a/docs/src/content/docs/docs/features/networking/network-request-prompts.md
+++ b/docs/src/content/docs/docs/features/networking/network-request-prompts.md
@@ -1,9 +1,11 @@
 ---
-title: "Exporting Network Requests as Prompts"
-description: "Turn captured network traffic into redacted exports and prompt-ready summaries for AI-assisted debugging, performance reviews, and failure analysis."
+title: "AI Network Request Prompts"
+description: "Export captured URLSession traffic as redacted prompts for Claude, ChatGPT, and other AI assistants to debug failures, duplicate calls, and slow endpoints."
 ---
 
 RocketSim can turn captured network traffic into a format that is much easier to share with AI coding assistants. Instead of pasting raw requests one by one, you can export a filtered request set as a compact summary or generate a built-in prompt tailored to the problem you want to investigate.
+
+This is useful when you want Claude, ChatGPT, or another coding assistant to review a real API session and look for patterns such as duplicate calls, slow endpoints, missing caching, oversized responses, or failure spikes.
 
 ## Where to find it
 

--- a/docs/src/content/docs/docs/features/networking/network-traffic-monitoring.md
+++ b/docs/src/content/docs/docs/features/networking/network-traffic-monitoring.md
@@ -1,9 +1,9 @@
 ---
-title: "Network Traffic Monitoring"
-description: "Monitor HTTP requests and responses from your Simulator app in real time. Inspect headers, bodies, status codes, and copy cURL commands for debugging."
+title: "Network Monitor"
+description: "Monitor URLSession requests from your iOS Simulator app without proxy certificates. Inspect headers, bodies, status codes, logs, and cURL commands."
 ---
 
-Powered by RocketSim Connect, you're able to monitor in- and outgoing network requests for your app.
+Powered by RocketSim Connect, you can monitor outgoing URLSession requests from your iOS Simulator app without setting up a proxy, installing custom certificates, or switching away from the Simulator.
 
 ::::tip[Debug networking without leaving the Simulator]
 See live requests, responses, logs, and shareable cURL commands in one place, without proxy certificates or switching tools.
@@ -13,7 +13,7 @@ Open the side window and select the **Networking** tab with the antenna icon. Ro
 
 ![Dedicated Networking tab showing recent network requests and the Open Network Monitor button](./network-traffic-monitoring/side_window_recent_network_requests_monitor.png)
 
-Being able to see which requests are running is essential for a fast development workflow.
+Being able to see which requests are running is essential for a fast development workflow. It helps you catch duplicate calls, failed responses, oversized payloads, and unexpected request order while the app is still running in the Simulator.
 
 RocketSim also shows connected app logs in the Network Monitor, so you can line up request traffic with what your app is printing at the same moment.
 
@@ -61,7 +61,9 @@ Nope! Integrating RocketSim Connect is all you need.
 
 ## Are you saying I don’t need Proxyman, Charles Proxy, or any other proxy app anymore?
 
-Basically, yes! However, RocketSim does not yet allow configuring breakpoints or adjusting responses before they return into your app. Though, in most cases, it's enough to be able to see which requests go in and out, what responses they return, and why a request failed.
+For everyday Simulator debugging, often yes. RocketSim is designed for quickly seeing which URLSession requests go in and out, what responses they return, and why a request failed.
+
+Proxy tools like Proxyman or Charles Proxy are still useful when you need advanced proxy workflows such as rewriting responses, breakpoints, or traffic from apps you cannot instrument. RocketSim focuses on the fast development loop for your own app: no proxy certificates, no system proxy setup, and request details next to your Simulator workflow.
 
 ## Powered by open-sourced framework Pulse
 


### PR DESCRIPTION
## Summary
- Refines non-article docs and feature-page metadata for Simulator Camera, Agentic Development, Agent Skill, Network Monitor, and AI network request prompts.
- Improves search-intent wording around iOS Simulator camera testing, agent-driven Simulator navigation, URLSession monitoring, proxy-free debugging, and AI-ready network exports.
- Clarifies RocketSim's Network Monitor positioning versus Proxyman/Charles while keeping the docs accurate.

## Test plan
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `npm run knip`