### PR TITLE
Fix features available only for enterprise in pricing table

### DIFF
--- a/docs/src/content/sections/compare-plans.md
+++ b/docs/src/content/sections/compare-plans.md
@@ -356,7 +356,7 @@ compare_plans:
         - item: Local-only mode by disabling build data syncing (extra privacy)
           free: false
           individual: false
-          teams: true
+          teams: Enterprise
     - title: Team manager
       list:
         - item: License management
@@ -370,7 +370,7 @@ compare_plans:
         - item: SAML based SSO
           free: false
           individual: false
-          teams: Coming soon (Enterprise)
+          teams: Enterprise
         - item: Distribution outside of the App Store
           free: false
           individual: false


### PR DESCRIPTION
Two small fixes on the comparisson table on the pricing page:

- Remove "coming soon" from Saml based SSO
- Local only build insights -> Enterprise only

<img width="2858" height="2424" alt="CleanShot 2026-06-24 at 14 50 16@2x" src="https://github.com/user-attachments/assets/12cd5bf8-f19e-4dd1-964f-6ceea00d40f0" />
