### PR TITLE
feat(docs): add "Copy as Markdown" button to docs pages

### DIFF
--- a/docs/src/components/starlight/PageTitle.astro
+++ b/docs/src/components/starlight/PageTitle.astro
@@ -1,12 +1,63 @@
 ---
 // Custom PageTitle component that displays the description as a subtitle
 // For the docs homepage, add CTA buttons after the description
-const { title, description } = Astro.locals.starlightRoute.entry.data;
+import { docBodyToMarkdown } from "@/lib/llms/page-markdown";
+
+const entry = Astro.locals.starlightRoute.entry;
+const { title, description } = entry.data;
 const id = Astro.locals.starlightRoute.id;
 const isHomepage = id === "docs";
+
+// Precompute the clean Markdown for the "Copy as Markdown" button, reusing the
+// same conversion as the `llms.txt` export (custom shortcodes → plain links).
+// Embedded inline so copying works identically in `astro dev` and production
+// without depending on a separate route. Escape `<` so the JSON payload can't
+// break out of the surrounding <script> tag.
+const pageMarkdown = isHomepage ? "" : docBodyToMarkdown(entry);
+const pageMarkdownJson = JSON.stringify(pageMarkdown).replace(/</g, "\\u003c");
 ---
 
-<h1 id="_top">{title}</h1>
+<div class="page-title-row">
+  <h1 id="_top">{title}</h1>
+  {
+    !isHomepage && (
+      <div class="copy-page-controls">
+        <div class="copy-page-live" aria-live="polite" aria-atomic="true" />
+        <button
+          type="button"
+          class="copy-page-button"
+          data-copy-page
+          data-copy-label="Copy as Markdown"
+          data-copy-success="Copied!"
+          data-copy-error="Copy failed"
+          title="Copy this page as Markdown"
+          aria-label="Copy this page as Markdown"
+        >
+          <span class="copy-page-icon" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.75"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M3 19a2 2 0 0 1-1-2V2a2 2 0 0 1 1-1h13a2 2 0 0 1 2 1" />
+              <rect x="6" y="5" width="16" height="18" rx="1.5" ry="1.5" />
+            </svg>
+          </span>
+          <span class="copy-page-label">Copy as Markdown</span>
+        </button>
+        <script
+          type="application/json"
+          data-copy-page-markdown
+          set:html={pageMarkdownJson}
+        />
+      </div>
+    )
+  }
+</div>
 {description && <p class="page-subtitle">{description}</p>}
 {
   isHomepage && (
@@ -25,13 +76,102 @@ const isHomepage = id === "docs";
 }
 
 <style>
+  .page-title-row {
+    margin-top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
   h1 {
     margin-bottom: 0.5rem;
-    margin-top: 1rem;
+    margin-top: 0;
+    min-width: 0;
     font-size: var(--sl-text-h1);
     line-height: var(--sl-line-height-headings);
     font-weight: 600;
     color: var(--sl-color-white);
+  }
+
+  .copy-page-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    /* Sit above the title (h1 stays first in the DOM for reading order) and
+       align to the right edge. */
+    order: -1;
+    align-self: flex-end;
+  }
+
+  /* Visually hidden: announces state changes to screen readers only, so the
+     in-button label is the sole visible "Copied!" feedback. */
+  .copy-page-live {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .copy-page-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.7rem;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 9999px;
+    background: var(--sl-color-black);
+    color: var(--sl-color-gray-2);
+    font-size: var(--sl-text-xs);
+    font-weight: 500;
+    line-height: 1.2;
+    white-space: nowrap;
+    cursor: pointer;
+    transition:
+      color 0.2s ease,
+      border-color 0.2s ease,
+      background 0.2s ease;
+  }
+
+  .copy-page-button:hover {
+    color: var(--sl-color-white);
+    border-color: var(--sl-color-accent);
+  }
+
+  .copy-page-button:focus-visible {
+    outline: 2px solid var(--sl-color-accent);
+    outline-offset: 2px;
+  }
+
+  .copy-page-button.is-success {
+    color: var(--sl-color-white);
+    border-color: var(--sl-color-accent);
+  }
+
+  .copy-page-button.is-error {
+    color: var(--sl-color-white);
+    border-color: var(--sl-color-red-high, #f87171);
+  }
+
+  .copy-page-icon {
+    display: inline-flex;
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+
+  .copy-page-icon svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .copy-page-button.is-success .copy-page-icon,
+  .copy-page-button.is-error .copy-page-icon {
+    display: none;
   }
 
   .page-subtitle {
@@ -94,3 +234,78 @@ const isHomepage = id === "docs";
     border-color: #e9ecef;
   }
 </style>
+
+<script is:inline>
+  (() => {
+    if (window.__copyPageMarkdownInit) return;
+    window.__copyPageMarkdownInit = true;
+
+    const REVERT_MS = 2200;
+
+    // Read the Markdown embedded next to the button by the server (same
+    // conversion as the llms export). Works identically in dev and production.
+    const readMarkdown = (button) => {
+      const el = button.parentElement?.querySelector(
+        "[data-copy-page-markdown]",
+      );
+      if (!el?.textContent) throw new Error("No markdown payload");
+      return JSON.parse(el.textContent);
+    };
+
+    const copyText = async (text) => {
+      if (navigator.clipboard?.writeText && window.isSecureContext) {
+        await navigator.clipboard.writeText(text);
+        return;
+      }
+      // Fallback for non-secure contexts (e.g. plain-HTTP previews).
+      const helper = document.createElement("textarea");
+      helper.value = text;
+      helper.setAttribute("readonly", "");
+      helper.style.position = "absolute";
+      helper.style.left = "-9999px";
+      document.body.appendChild(helper);
+      helper.select();
+      const ok = document.execCommand("copy");
+      document.body.removeChild(helper);
+      if (!ok) throw new Error("Copy command failed");
+    };
+
+    const setState = (button, label, className) => {
+      const labelEl = button.querySelector(".copy-page-label");
+      const live = button.parentElement?.querySelector(".copy-page-live");
+      if (labelEl) labelEl.textContent = label;
+      if (live) live.textContent = label;
+      button.classList.remove("is-success", "is-error");
+      if (className) button.classList.add(className);
+    };
+
+    const reset = (button) => {
+      setState(button, button.dataset.copyLabel || "Copy as Markdown", "");
+      const live = button.parentElement?.querySelector(".copy-page-live");
+      if (live) live.textContent = "";
+    };
+
+    document.addEventListener("click", async (event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      const button = target.closest("[data-copy-page]");
+      if (!button) return;
+
+      window.clearTimeout(Number(button.dataset.copyTimer));
+
+      try {
+        await copyText(readMarkdown(button));
+        setState(button, button.dataset.copySuccess || "Copied!", "is-success");
+        window.plausible?.("Copy as Markdown", {
+          props: { surface: "docs", placement: "docs-page-title" },
+        });
+      } catch {
+        setState(button, button.dataset.copyError || "Copy failed", "is-error");
+      }
+
+      button.dataset.copyTimer = String(
+        window.setTimeout(() => reset(button), REVERT_MS),
+      );
+    });
+  })();
+</script>

--- a/docs/src/integrations/llms-txt-post-process.ts
+++ b/docs/src/integrations/llms-txt-post-process.ts
@@ -2,6 +2,14 @@ import type { AstroIntegration } from "astro";
 import { readFile, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
+import {
+  collapseBlankLines,
+  convertDirectivesToBlockquotes,
+  convertShortcodesToLinks,
+  fixBoldInLink,
+  stripDirectives,
+  stripJsxArtifacts,
+} from "../lib/llms/page-markdown";
 
 /**
  * Post-processes the generated llms-full.txt and llms-small.txt files to:
@@ -124,27 +132,10 @@ function transformLlmsTxt(content: string, variant: "full" | "small"): string {
 
   let result = systemHeader + filteredPages.join("");
 
-  // Convert <Youtube> components to markdown links (handles multi-line tags)
-  result = result.replace(/<Youtube[\s\S]*?\/>/g, (match) => {
-    const idMatch = match.match(/id="([^"]+)"/);
-    const titleMatch = match.match(/title="([^"]+)"/);
-    const id = idMatch?.[1];
-    const title = titleMatch?.[1] ?? "YouTube video";
-    return id ? `[${title}](https://www.youtube.com/watch?v=${id})` : match;
-  });
-
-  // Convert <Tweet> components to X links
-  result = result.replace(/<Tweet[\s\S]*?\/>/g, (match) => {
-    const idMatch = match.match(/id="([^"]+)"/);
-    const id = idMatch?.[1];
-    return id ? `https://x.com/x/status/${id}` : match;
-  });
-
-  // Remove import statements
-  result = result.replace(/^import\s+.+$/gm, "");
-
-  // Remove style blocks
-  result = result.replace(/<style>\{`[\s\S]*?`\}<\/style>/g, "");
+  // Convert <Youtube>/<Tweet> shortcodes to links and strip JSX artifacts.
+  // Shared with the per-page "Copy as Markdown" export so both stay identical.
+  result = convertShortcodesToLinks(result);
+  result = stripJsxArtifacts(result);
 
   // Strip all image references for small variant only
   if (variant === "small") {
@@ -154,35 +145,13 @@ function transformLlmsTxt(content: string, variant: "full" | "small"): string {
 
   // Handle :::tip/:::note/:::caution/:::danger directives
   if (variant === "full") {
-    // Convert to blockquotes
-    result = result.replace(
-      /^:::(tip|note|caution|danger)\n([\s\S]*?)^:::/gm,
-      (_match, type: string, content: string) => {
-        const label = type.charAt(0).toUpperCase() + type.slice(1);
-        const quoted = content
-          .trimEnd()
-          .split("\n")
-          .map((line) => `> ${line}`)
-          .join("\n");
-        return `> **${label}:** ${quoted.slice(2)}`;
-      },
-    );
+    result = convertDirectivesToBlockquotes(result);
   } else {
-    // Strip directives entirely for small variant
-    result = result.replace(
-      /^:::(tip|note|caution|danger)\n[\s\S]*?^:::/gm,
-      "",
-    );
+    result = stripDirectives(result);
   }
 
-  // Fix escaped bold-in-link markdown: [\*\*text](url).\*\* → [**text**](url).
-  result = result.replace(
-    /\[\\\*\\\*(.+?)\]\((.+?)\)\.\\\*\\\*/g,
-    "[**$1**]($2).",
-  );
-
-  // Collapse excessive blank lines (3+ newlines → 2)
-  result = result.replace(/\n{3,}/g, "\n\n");
+  result = fixBoldInLink(result);
+  result = collapseBlankLines(result);
 
   return result;
 }

--- a/docs/src/lib/llms/page-markdown.ts
+++ b/docs/src/lib/llms/page-markdown.ts
@@ -1,0 +1,108 @@
+import type { CollectionEntry } from "astro:content";
+
+/**
+ * Shared content-level Markdown transforms.
+ *
+ * These mirror the conversions applied when generating `llms.txt` /
+ * `llms-full.txt` so that the "Copy as Markdown" button and the LLM export
+ * produce identical output. Each function is a pure string transform, letting
+ * them be composed both here (for a single page, see {@link docBodyToMarkdown})
+ * and in `src/integrations/llms-txt-post-process.ts` (for the combined file).
+ */
+
+/**
+ * Convert custom `<Youtube>` and `<Tweet>` shortcodes to plain Markdown links.
+ * Handles multi-line self-closing tags.
+ */
+export function convertShortcodesToLinks(text: string): string {
+  let result = text.replace(/<Youtube[\s\S]*?\/>/g, (match) => {
+    const id = match.match(/id="([^"]+)"/)?.[1];
+    const url = match.match(/url="([^"]+)"/)?.[1];
+    const title = match.match(/title="([^"]+)"/)?.[1] ?? "YouTube video";
+    // The <Youtube> shortcode accepts either an `id` or a full `url`.
+    const href = id ? `https://www.youtube.com/watch?v=${id}` : url;
+    return href ? `[${title}](${href})` : match;
+  });
+
+  result = result.replace(/<Tweet[\s\S]*?\/>/g, (match) => {
+    const idMatch = match.match(/id="([^"]+)"/);
+    const id = idMatch?.[1];
+    return id ? `https://x.com/x/status/${id}` : match;
+  });
+
+  return result;
+}
+
+/** Strip leftover JSX artifacts: `import` statements and inline `<style>` blocks. */
+export function stripJsxArtifacts(text: string): string {
+  let result = text.replace(/^import\s+.+$/gm, "");
+  result = result.replace(/<style>\{`[\s\S]*?`\}<\/style>/g, "");
+  return result;
+}
+
+/**
+ * Convert Starlight `:::tip/:::note/:::caution/:::danger` directives to
+ * blockquotes.
+ */
+export function convertDirectivesToBlockquotes(text: string): string {
+  return text.replace(
+    /^:::(tip|note|caution|danger)\n([\s\S]*?)^:::/gm,
+    (_match, type: string, content: string) => {
+      const label = type.charAt(0).toUpperCase() + type.slice(1);
+      const quoted = content
+        .trimEnd()
+        .split("\n")
+        .map((line) => `> ${line}`)
+        .join("\n");
+      return `> **${label}:** ${quoted.slice(2)}`;
+    },
+  );
+}
+
+/** Strip Starlight `:::tip/:::note/:::caution/:::danger` directives entirely. */
+export function stripDirectives(text: string): string {
+  return text.replace(/^:::(tip|note|caution|danger)\n[\s\S]*?^:::/gm, "");
+}
+
+/** Fix escaped bold-in-link markdown: `[\*\*text](url).\*\*` → `[**text**](url).` */
+export function fixBoldInLink(text: string): string {
+  return text.replace(/\[\\\*\\\*(.+?)\]\((.+?)\)\.\\\*\\\*/g, "[**$1**]($2).");
+}
+
+/** Collapse excessive blank lines (3+ newlines → 2). */
+export function collapseBlankLines(text: string): string {
+  return text.replace(/\n{3,}/g, "\n\n");
+}
+
+/**
+ * Convert a single docs entry's raw body into clean Markdown, applying the same
+ * content-level transforms used for the full `llms` export (full variant:
+ * shortcodes → links, JSX artifacts stripped, directives → blockquotes).
+ */
+function transformPageBody(body: string): string {
+  let result = convertShortcodesToLinks(body);
+  result = stripJsxArtifacts(result);
+  result = convertDirectivesToBlockquotes(result);
+  result = fixBoldInLink(result);
+  result = collapseBlankLines(result);
+  return result.trim();
+}
+
+/**
+ * Build a complete Markdown document for a docs entry, mirroring how
+ * `starlight-llms-txt`'s generator composes each page segment: a top-level
+ * `# title`, an optional `> description`, then the transformed body.
+ */
+export function docBodyToMarkdown(entry: CollectionEntry<"docs">): string {
+  const { data, body } = entry;
+  const title = data.hero?.title || data.title;
+  const description = data.hero?.tagline || data.description;
+
+  const segments = [`# ${title}`];
+  if (description) segments.push(`> ${description}`);
+
+  const transformedBody = transformPageBody(body ?? "");
+  if (transformedBody) segments.push(transformedBody);
+
+  return `${segments.join("\n\n")}\n`;
+}

--- a/docs/src/lib/llms/page-markdown.ts
+++ b/docs/src/lib/llms/page-markdown.ts
@@ -27,7 +27,8 @@ export function convertShortcodesToLinks(text: string): string {
   result = result.replace(/<Tweet[\s\S]*?\/>/g, (match) => {
     const idMatch = match.match(/id="([^"]+)"/);
     const id = idMatch?.[1];
-    return id ? `https://x.com/x/status/${id}` : match;
+    // `/i/status/` is the canonical, username-independent permalink form.
+    return id ? `https://x.com/i/status/${id}` : match;
   });
 
   return result;
@@ -45,10 +46,21 @@ export function stripJsxArtifacts(text: string): string {
  * blockquotes.
  */
 export function convertDirectivesToBlockquotes(text: string): string {
+  // Handles 3+ colons (`:::`, `::::`) and an optional custom title in brackets
+  // (`:::tip[My title]`). The closer is backreferenced so its colon count
+  // matches the opener.
   return text.replace(
-    /^:::(tip|note|caution|danger)\n([\s\S]*?)^:::/gm,
-    (_match, type: string, content: string) => {
-      const label = type.charAt(0).toUpperCase() + type.slice(1);
+    /^(:{3,})(tip|note|caution|danger)(?:\[([^\]\n]*)\])?[ \t]*\n([\s\S]*?)^\1[ \t]*$/gm,
+    (
+      _match,
+      _colons: string,
+      type: string,
+      customTitle: string | undefined,
+      content: string,
+    ) => {
+      const label = customTitle?.trim()
+        ? customTitle.trim()
+        : type.charAt(0).toUpperCase() + type.slice(1);
       const quoted = content
         .trimEnd()
         .split("\n")
@@ -61,7 +73,10 @@ export function convertDirectivesToBlockquotes(text: string): string {
 
 /** Strip Starlight `:::tip/:::note/:::caution/:::danger` directives entirely. */
 export function stripDirectives(text: string): string {
-  return text.replace(/^:::(tip|note|caution|danger)\n[\s\S]*?^:::/gm, "");
+  return text.replace(
+    /^(:{3,})(tip|note|caution|danger)(?:\[[^\]\n]*\])?[ \t]*\n[\s\S]*?^\1[ \t]*$/gm,
+    "",
+  );
 }
 
 /** Fix escaped bold-in-link markdown: `[\*\*text](url).\*\*` → `[**text**](url).` */


### PR DESCRIPTION
## What

Adds a **Copy as Markdown** button to every docs content page. It sits above the page title, right-aligned, and copies a clean Markdown version of the page to the clipboard with brief "Copied!" feedback — so developers and LLMs can grab a page easily.

Placement/appearance is modelled on the [`starlight-copy-button`](https://github.com/dionysuzx/starlight-copy-button) plugin, but the Markdown is generated by **reusing our existing `llms.txt` conversion** rather than a new client-side HTML→Markdown converter (no new dependencies).

## How

- **`src/lib/llms/page-markdown.ts`** (new) — extracts the content-level Markdown transforms (`<Youtube>`/`<Tweet>` → plain links, JSX-artifact stripping, `:::` directives → blockquotes, etc.) into a shared module, plus `docBodyToMarkdown(entry)` that composes a page exactly like the llms generator (`# title` / `> description` / body).
- **`src/integrations/llms-txt-post-process.ts`** — refactored to reuse those helpers, so the button and the llms export produce identical output. Also fixes a latent gap: the `<Youtube url="…">` variant was previously left as raw JSX in `llms-full.txt`; now both `id` and `url` variants convert.
- **`src/components/starlight/PageTitle.astro`** — renders the button, embeds the page Markdown inline (works identically in `astro dev` and production, no extra route), scoped theme-matched styles, an inline copy script (with a non-secure-context fallback), a visually-hidden `aria-live` region for screen readers, and a Plausible `Copy as Markdown` event on success.

### Note on approach
Initially implemented as a static `.md` endpoint, but Starlight's `/docs/*` catch-all shadows it in `astro dev` (404), so the Markdown is embedded inline instead — largest page ~12.6 KB, most 2–6 KB, gzips to a few KB.

## Verification

- Quality gate all green: `lint`, `format:check`, `typecheck` (0 errors), `build`, `knip`.
- Button present on content pages, absent on the docs index.
- Copied Markdown is clean; `<Youtube>` (both variants) renders as `[title](youtube link)`, not raw markup.
- Inline JSON payload round-trips through `JSON.parse` (checked on the 12.6 KB code-heavy CLI page).

_Before/after screenshot to be added._

🤖 Generated with [Claude Code](https://claude.com/claude-code)