### PR TITLE
Fix changelog RSS fragment links

### DIFF
--- a/docs/src/pages/changelog/rss.xml.ts
+++ b/docs/src/pages/changelog/rss.xml.ts
@@ -45,7 +45,7 @@ export function GET(context: { site?: URL }) {
         description: release.summary,
         content: releaseContentHtml(release),
         pubDate: new Date(`${release.date}T00:00:00Z`),
-        link: `/changelog/#${release.slug}`,
+        link: new URL(`/changelog/#${release.slug}`, site).toString(),
       })),
   });
 }


### PR DESCRIPTION
## Summary
- Generate changelog RSS item links from the configured site URL so release anchors remain `#version` instead of getting a trailing slash appended after the fragment.

## Test plan
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `npm run knip`
- Verified `dist/changelog/rss.xml` contains `https://www.rocketsim.app/changelog/#16-2-0`.