### PR TITLE
Fix changelog text wrapping on mobile viewports

### DIFF
--- a/docs/src/lib/changelog.ts
+++ b/docs/src/lib/changelog.ts
@@ -7,6 +7,11 @@ type ChangelogSection = {
   html: string;
 };
 
+type MarkdownSection = {
+  title: string;
+  markdown: string;
+};
+
 type ChangelogRelease = {
   version: string;
   build?: string;
@@ -95,9 +100,10 @@ function parseEntries(markdown: string) {
   return entries;
 }
 
-function normalizeSections(body: string) {
+function normalizeSections(body: string): MarkdownSection[] {
   const sections = new Map<string, string[]>();
   let currentTitle = "Changes";
+  let skippingMetadata = false;
 
   const appendLine = (title: string, line: string) => {
     const lines = sections.get(title) ?? [];
@@ -112,6 +118,7 @@ function normalizeSections(body: string) {
     const inlineBullet = trimmed.match(/^[-*]\s+([A-Z][A-Z ]+):\s+(.+)$/);
 
     if (boldHeading) {
+      skippingMetadata = false;
       currentTitle = normalizeSectionTitle(boldHeading[1]) ?? boldHeading[1];
       continue;
     }
@@ -119,9 +126,19 @@ function normalizeSections(body: string) {
     if (bareHeading) {
       const normalizedTitle = normalizeSectionTitle(bareHeading[1]);
       if (normalizedTitle) {
+        skippingMetadata = false;
         currentTitle = normalizedTitle;
-        continue;
+      } else {
+        // Unrecognized all-caps headings (e.g. "NEW SUBTITLE", "NEW KEYWORDS")
+        // are App Store metadata leaked into the changelog. Drop the heading
+        // and everything under it until the next real section heading.
+        skippingMetadata = true;
       }
+      continue;
+    }
+
+    if (skippingMetadata) {
+      continue;
     }
 
     if (inlineBullet) {
@@ -141,11 +158,7 @@ function normalizeSections(body: string) {
       title,
       markdown: lines.join("\n").trim(),
     }))
-    .filter((section) => section.markdown.length > 0)
-    .map((section) => ({
-      title: section.title,
-      html: markdownToHtml(section.markdown),
-    }));
+    .filter((section) => section.markdown.length > 0);
 }
 
 function mergeDuplicateVersions(entries: ParsedEntry[]) {
@@ -173,15 +186,20 @@ export function parseChangelog(
   releaseDates: ReleaseDateMap,
 ): ChangelogRelease[] {
   return mergeDuplicateVersions(parseEntries(markdown)).map((entry) => {
-    const sections = normalizeSections(entry.body);
+    const markdownSections = normalizeSections(entry.body);
 
     return {
       version: entry.version,
       build: entry.build,
       date: releaseDates[entry.version],
       slug: slugForVersion(entry.version),
-      sections,
-      summary: summarizeMarkdown(entry.body),
+      sections: markdownSections.map((section) => ({
+        title: section.title,
+        html: markdownToHtml(section.markdown),
+      })),
+      summary: summarizeMarkdown(
+        markdownSections.map((section) => section.markdown).join("\n\n"),
+      ),
     };
   });
 }

--- a/docs/src/pages/changelog.astro
+++ b/docs/src/pages/changelog.astro
@@ -136,7 +136,7 @@ const structuredData = {
         }
       </div>
 
-      <div class="grid gap-8 lg:grid-cols-[220px_minmax(0,1fr)]">
+      <div class="grid grid-cols-1 gap-8 lg:grid-cols-[220px_minmax(0,1fr)]">
         <aside class="hidden lg:block">
           <nav
             class="sticky top-28 rounded-2xl border border-border/60 bg-theme-light/40 p-5"
@@ -162,7 +162,7 @@ const structuredData = {
           </nav>
         </aside>
 
-        <div class="space-y-10">
+        <div class="min-w-0 space-y-10">
           {
             releases.map((release) => (
               <article
@@ -192,7 +192,7 @@ const structuredData = {
                         {section.title}
                       </h3>
                       <div
-                        class="prose prose-invert max-w-none prose-li:my-1 prose-a:text-primary"
+                        class="prose prose-invert max-w-none break-words prose-li:my-1 prose-a:text-primary prose-code:[overflow-wrap:anywhere]"
                         set:html={section.html}
                       />
                     </section>


### PR DESCRIPTION
## Summary

- The changelog page overflowed horizontally on mobile because the 10.4.0 entry contains leaked App Store metadata ("NEW SUBTITLE" / "NEW KEYWORDS") with ~100-character unbreakable keyword strings. Since `changelog.md` is overwritten by the automated sync, the parser in `src/lib/changelog.ts` now drops unrecognized all-caps metadata headings and their content until the next real section heading. Release summaries (used for structured data and RSS) are now built from the filtered sections too.
- Added wrapping fallbacks in `changelog.astro`: `break-words` plus `overflow-wrap: anywhere` on inline code so long tokens like `CGPreflightScreenCaptureAccess` wrap inside release cards, and an explicit `grid-cols-1` / `min-w-0` so content can't stretch the layout.

## Test plan

- [x] Verified at 375x812 with headless Chromium: no horizontal overflow (`document.scrollWidth` = 375, zero offending elements), 10.4.0 entry no longer shows keyword junk, long code tokens wrap within cards
- [x] `npm run lint`, `format:check`, `typecheck`, `build`, `knip` all pass
- [x] Built `dist/changelog/index.html` and `rss.xml` contain no leaked metadata