### PR TITLE
Queue GitHub Pages deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 
+concurrency:
+  group: github-pages-deploy
+  cancel-in-progress: false
+
 # Allow this job to clone the repo and create a page deployment
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Adds a top-level concurrency group to the GitHub Pages deploy workflow.
- Prevents back-to-back `master` pushes from racing and failing with an in-progress Pages deployment error.

## Test plan

- [x] `git diff --check`
- [x] Confirmed the previously merged changelog fix is live on production after manually rerunning the deploy workflow
- [x] Verified production `/changelog/` at 375px has `document.scrollWidth === 375` with zero overflowing elements