### PR TITLE
Improve Teams trial conversion handoff

### DIFF
--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -1,0 +1,33 @@
+# Teams funnel analytics
+
+Plausible event names are part of the site's historical reporting contract. Do
+not rename an existing event when its destination or copy changes. Add a new
+event only when tracking a genuinely new action.
+
+## Existing Teams events
+
+- `CTA: Homepage Insights - Learn More` opens `/for-teams`.
+- `CTA: Homepage Mid 2 - Trial` opens `/for-teams`. The historical name says
+  "Trial," but the action only opens Teams information. Keep the event name and
+  describe it as a Teams information click in Plausible.
+- `CTA: Team Page - See Pricing` opens `/pricing/`.
+- `CTA: Team Page - Start Trial` opens the Teams trial form from the hero or
+  bottom call-to-action.
+- `CTA: Team Page - Proof Start Trial` opens the Teams trial form from the proof
+  section.
+- `CTA: Pricing Teams - Trial` opens the Teams trial form from the pricing
+  comparison.
+- `CTA: Pricing Teams - Buy Now` opens the direct Teams checkout.
+- `CTA: Pricing Bottom - Trial` opens the Teams trial form from the pricing
+  page's bottom call-to-action.
+- `CTA: Blog Bottom - Trial` opens the Teams trial form from a blog post's
+  bottom call-to-action.
+
+## Trial completion
+
+Configure `/signup/trial/thank-you/` as a Plausible pageview goal. The page is
+the successful trial-creation destination, so using its existing pageviews
+preserves historical data without introducing another custom event.
+
+The goal is directional until `www.rocketsim.app` and `teams.rocketsim.app`
+have been verified to use the same Plausible site ID and script.

--- a/docs/src/components/starlight/Footer.astro
+++ b/docs/src/components/starlight/Footer.astro
@@ -11,7 +11,7 @@ import { Icon } from "@astrojs/starlight/components";
 
 <div class="footer-links">
   <a href="/"><Icon name="rocket" /> Home</a>
-  <a href="/team-insights"><Icon name="star" /> For teams</a>
+  <a href="/for-teams"><Icon name="star" /> For teams</a>
   <a
     href="https://apps.apple.com/app/apple-store/id1504940162?pt=117264678&ct=docs-footer&mt=8"
     target="_blank"

--- a/docs/src/content/blog/monitor-urlsession-network-requests-without-the-pain-of-custom-certificates/index.mdx
+++ b/docs/src/content/blog/monitor-urlsession-network-requests-without-the-pain-of-custom-certificates/index.mdx
@@ -43,7 +43,7 @@ private func loadRocketSimConnect() {
 }
 ```
 
-As you can see, the method will only run for debug builds due to the `#if DEBUG`. Secondly, this code works for every engineer in your team in case you're using [Team Licenses](https://www.rocketsim.app/team-insights). At least, as long as they've installed RocketSim inside the `/Applications` directory, which we recommend!
+As you can see, the method will only run for debug builds due to the `#if DEBUG`. Secondly, this code works for every engineer in your team in case you're using [Team Licenses](https://www.rocketsim.app/for-teams/). At least, as long as they've installed RocketSim inside the `/Applications` directory, which we recommend!
 
 Once you've copied the code, it's time to run your app. Every time when you launch your app, RocketSim will connect directly. From that point on, all your network requests will be monitored in the background. **There's no impact on your app's performance.**
 

--- a/docs/src/content/docs/docs/features/build-insights/team-build-insights.md
+++ b/docs/src/content/docs/docs/features/build-insights/team-build-insights.md
@@ -67,4 +67,4 @@ No. RocketSim tracks build data in the background and syncs at most once per hou
 
 **How do we try this with a team?**
 
-[Start a 14-day Teams trial](https://teams.rocketsim.app/signup/trial) and connect developers with the same team license key. No credit card is required.
+[Start a 14-day Teams trial](https://teams.rocketsim.app/signup/trial?utm_source=website&utm_medium=website&utm_content=team_build_insights_docs) and connect developers with the same team license key. No credit card is required.

--- a/docs/src/content/docs/docs/getting-started/how-large-teams-use-rocketsim.md
+++ b/docs/src/content/docs/docs/getting-started/how-large-teams-use-rocketsim.md
@@ -15,7 +15,7 @@ Brand new since 2025 is our RocketSim for Teams dashboard.
 
 ![RocketSim Teams dashboard showing team build insights](./how-large-teams-use-rocketsim/cleanshot_2025-01-21_at_13.42.472x.png)
 
-You can find more info about this [on our website](https://www.rocketsim.app/team-insights).
+You can find more info about this [on our website](https://www.rocketsim.app/for-teams/).
 
 ## Sharing App Actions using Git
 
@@ -50,4 +50,4 @@ Besides developers, it’s also QA engineers and designers that benefit from Roc
 
 ## Purchasing Team Licenses
 
-You can [order team licenses via our website](https://www.rocketsim.app/team-insights). Batch discounts apply automatically if you order multiple seats.
+You can [order team licenses via our website](https://www.rocketsim.app/for-teams/). Batch discounts apply automatically if you order multiple seats.

--- a/docs/src/content/docs/docs/support/faq.md
+++ b/docs/src/content/docs/docs/support/faq.md
@@ -9,15 +9,15 @@ Yes, we do. Get in touch via [support@rocketsim.app](mailto:support@rocketsim.ap
 
 ## Are there non-recurring subscriptions as well?
 
-Yes, you can consider buying [Team Licenses](https://www.rocketsim.app/team-insights/).
+Yes, you can consider buying [Team Licenses](https://www.rocketsim.app/for-teams/).
 
 ## I can’t reimburse App Store subscriptions, is there an alternative?
 
-Yes, we offer [Team Licenses](https://www.rocketsim.app/team-insights/).
+Yes, we offer [Team Licenses](https://www.rocketsim.app/for-teams/).
 
 ## Do you provide the option for commercial or team licenses?
 
-Yes, check out [Team Licenses](https://www.rocketsim.app/team-insights/).
+Yes, check out [Team Licenses](https://www.rocketsim.app/for-teams/).
 
 ## Can I buy a lifetime license?
 

--- a/docs/src/content/sections/faq.md
+++ b/docs/src/content/sections/faq.md
@@ -10,7 +10,7 @@ list:
     answer: "Yes, you can invite your entire team. Simply specify your team size when starting the trial, and you'll receive the corresponding number of seats."
   - enable: true
     question: "What happens when my trial is over?"
-    answer: "You will have the option to convert to a paying plan or you'll loose access to RocketSim Pro features and team build insights."
+    answer: "You will have the option to convert to a paying plan or you'll lose access to RocketSim Pro features and team build insights."
   - enable: true
     question: "Can I cancel, upgrade, or downgrade anytime?"
     answer: "Yes. You can cancel, upgrade, or downgrade your plan via your subscription settings within the web app. All cancellations and downgrades will take place at the end of your plan cycle, while upgrades will take place immediately."

--- a/docs/src/old/components/TeamInsights.astro
+++ b/docs/src/old/components/TeamInsights.astro
@@ -73,7 +73,7 @@ import FeatureImage from "../../assets/features/build-insights.png";
   </div>
   <div class="deprecated-grid">
     <a
-      href="/team-insights"
+      href="/for-teams"
       class="learn-more plausible-event-name=CTA:+Homepage+Insights+-+Learn+More"
       >Learn more about Teams &rarr;</a
     >
@@ -87,7 +87,7 @@ import FeatureImage from "../../assets/features/build-insights.png";
       text="What's the build duration across the team? Does an M3 Max make a difference in terms of compilation time? With team insights, you'll be able to optimize productivity based on real build data"
     />
     <a
-      href="/team-insights"
+      href="/for-teams"
       class="button plausible-event-name=CTA:+Homepage+Mid+2+-+Trial"
       >Explore Team Insights</a
     >

--- a/docs/src/pages/for-teams.astro
+++ b/docs/src/pages/for-teams.astro
@@ -54,7 +54,7 @@ const structuredData = {
       See Team Pricing &rarr;
     </NavigationLink>
     <NavigationLink
-      href="https://teams.rocketsim.app/signup/trial"
+      href="https://teams.rocketsim.app/signup/trial?utm_source=website&utm_medium=website&utm_content=for_teams_hero"
       className="plausible-event-name=CTA:+Team+Page+-+Start+Trial"
     >
       Start 14-Day Trial
@@ -201,7 +201,7 @@ const structuredData = {
         </div>
         <div class="mt-10 flex justify-center">
           <a
-            href="https://teams.rocketsim.app/signup/trial"
+            href="https://teams.rocketsim.app/signup/trial?utm_source=website&utm_medium=website&utm_content=for_teams_proof"
             class="btn btn-primary plausible-event-name=CTA:+Team+Page+-+Proof+Start+Trial"
           >
             Start 14-Day Trial

--- a/docs/src/pages/privacy.astro
+++ b/docs/src/pages/privacy.astro
@@ -62,7 +62,7 @@ const seo = {
   </Header>
   <Navigation>
     <NavigationLink href="/"> All Features </NavigationLink>
-    <NavigationLink href="/team-insights">For Teams</NavigationLink>
+    <NavigationLink href="/for-teams">For Teams</NavigationLink>
   </Navigation>
   <div class="deprecated-grid">
     <div>

--- a/docs/src/pages/signup/trial/thank-you.astro
+++ b/docs/src/pages/signup/trial/thank-you.astro
@@ -10,7 +10,7 @@ const pageIndex = await getEntry("thank-you", "-index");
 if (!pageIndex) return null;
 const { title, meta_title, description } = pageIndex.data;
 const {
-  site: { base_url },
+  site: { base_url, teams_base_url },
 } = config;
 
 // Build SEO object
@@ -68,6 +68,23 @@ const seo = {
     text-align: center;
   }
 
+  .next-steps {
+    max-width: 42rem;
+    margin: 2rem auto 0;
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 2rem;
+  }
+
+  .support {
+    margin-top: 1.5rem;
+  }
+
   .newsletter {
     padding: 4rem 0;
     margin: 0;
@@ -87,14 +104,30 @@ const seo = {
   <div class="thank-you-wrapper">
     <section class="deprecated-grid thank-you">
       <SectionHeader title="Check your inbox!" />
-      <p>
-        You&apos;re invited for a 14 days trial for RocketSim for Teams. Check
-        your email on how to get started.
-      </p>
+      <div class="next-steps">
+        <p>
+          Your 14-day RocketSim for Teams trial is ready. Open the invitation
+          email to set your password, then sign in to connect your first
+          developer.
+        </p>
+        <div class="actions">
+          <a class="btn btn-primary" href={`${teams_base_url}/login`}>
+            Open Teams dashboard
+          </a>
+          <a class="btn btn-secondary" href="/docs/getting-started/onboarding/">
+            Read the setup guide
+          </a>
+        </div>
+        <p class="support">
+          Didn&apos;t receive the invitation? Check your spam folder or <a
+            href="mailto:support@rocketsim.app">contact support</a
+          >.
+        </p>
+      </div>
     </section>
     <section class="newsletter">
       <SectionHeader
-        title="While you await your invitation email"
+        title="Get more from RocketSim"
         subtitle="Subscribe to our newsletter"
         smallTitle
         text="And be the first to discover new features & time-saving tricks."

--- a/docs/src/pages/terms.astro
+++ b/docs/src/pages/terms.astro
@@ -124,7 +124,7 @@ const seo = {
   </Header>
   <Navigation>
     <NavigationLink href="/"> All Features </NavigationLink>
-    <NavigationLink href="/team-insights">For Teams</NavigationLink>
+    <NavigationLink href="/for-teams">For Teams</NavigationLink>
   </Navigation>
   <div class="deprecated-grid">
     <div>


### PR DESCRIPTION
## Summary
- preserve existing Plausible event names while documenting their actual Teams funnel semantics
- add consistent attribution to missing trial links and remove legacy `/team-insights` redirect hops
- turn the trial thank-you page into an onboarding handoff with dashboard, setup, and support actions

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run knip`