### PR TITLE
Add reusable email-notify confirmation page for Kit link triggers

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -19,11 +19,10 @@ import config from "./src/config/config.json";
 // Heading anchors are generated at build time for blog posts only. Starlight
 // already manages slugs/anchors for the docs collection, so we scope these
 // plugins to files under `src/content/blog` to avoid double-processing docs.
-const scopeToBlog =
-  <S extends unknown[]>(
-    plugin: Plugin<S, Root>,
-    ...settings: S
-  ): Plugin<[], Root> =>
+const scopeToBlog = <S extends unknown[]>(
+  plugin: Plugin<S, Root>,
+  ...settings: S
+): Plugin<[], Root> =>
   function () {
     const transformer = plugin.call(this, ...settings) as Transformer<
       Root,
@@ -133,14 +132,21 @@ export default defineConfig({
   integrations: [
     react(),
     sitemap({
-      filter: (page) =>
-        page !== "https://www.rocketsim.app/terms" &&
-        page !== "https://www.rocketsim.app/privacy" &&
-        page !== "https://www.rocketsim.app/thank-you" &&
-        page !== "https://www.rocketsim.app/claim-offer" &&
-        page !== "https://www.rocketsim.app/signup/trial/thank-you" &&
-        page !== "https://www.rocketsim.app/404" &&
-        page !== "https://www.rocketsim.app/docs/404",
+      // Compare without the trailing slash: the site is configured with
+      // `trailingSlash: "always"`, so sitemap entries end in `/`.
+      filter: (page) => {
+        const normalized = page.replace(/\/$/, "");
+        return ![
+          "https://www.rocketsim.app/terms",
+          "https://www.rocketsim.app/privacy",
+          "https://www.rocketsim.app/thank-you",
+          "https://www.rocketsim.app/claim-offer",
+          "https://www.rocketsim.app/emails-notify",
+          "https://www.rocketsim.app/signup/trial/thank-you",
+          "https://www.rocketsim.app/404",
+          "https://www.rocketsim.app/docs/404",
+        ].includes(normalized);
+      },
     }),
     AutoImport({
       imports: [

--- a/docs/src/pages/emails-notify.astro
+++ b/docs/src/pages/emails-notify.astro
@@ -1,0 +1,67 @@
+---
+import config from "@/config/config.json";
+import Base from "@/layouts/Base.astro";
+
+const {
+  site: { base_url },
+} = config;
+
+const seo = {
+  title: "Email Preferences Updated | RocketSim",
+  description: "Your RocketSim email preferences have been updated.",
+  canonical: `${base_url}/emails-notify`,
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+---
+
+<Base seo={seo}>
+  <section class="py-48 text-center">
+    <div class="container mx-auto px-4">
+      <h1 id="notify-title" class="text-4xl font-bold mb-4">
+        Email preferences updated
+      </h1>
+      <p id="notify-body" class="text-xl text-gray-400 mb-8">
+        Your email preferences have been updated.
+      </p>
+      <a href="https://www.rocketsim.app/" class="btn btn-primary"
+        >Back to RocketSim</a
+      >
+    </div>
+  </section>
+</Base>
+
+<script is:inline>
+  // Messages are selected by key only; query values are never rendered
+  // directly to avoid content injection on this domain.
+  (function () {
+    var messages = {
+      "trial-tips-stopped": {
+        title: "Trial tips stopped",
+        body: "You'll no longer receive RocketSim for Teams trial tips. You'll still receive essential account emails, such as setup instructions and trial expiry notices.",
+      },
+      subscribed: {
+        title: "You're subscribed",
+        body: "Your email preferences were updated. You'll now receive these emails from RocketSim.",
+      },
+      unsubscribed: {
+        title: "You're unsubscribed",
+        body: "Your email preferences were updated. You won't receive these emails anymore.",
+      },
+    };
+
+    var key = new URLSearchParams(window.location.search).get("m");
+    var message =
+      key && Object.prototype.hasOwnProperty.call(messages, key)
+        ? messages[key]
+        : null;
+    if (!message) return;
+
+    var title = document.getElementById("notify-title");
+    var body = document.getElementById("notify-body");
+    if (title) title.textContent = message.title;
+    if (body) body.textContent = message.body;
+  })();
+</script>


### PR DESCRIPTION
## Summary
- Adds `docs/src/pages/emails-notify.astro`, a reusable confirmation/landing page for Kit (ConvertKit) link triggers and email automations at `https://www.rocketsim.app/emails-notify`.
- The message is selected via a `?m=<key>` query parameter from a predefined key → `{ title, body }` map, read client-side with a small inline script (the site is statically built, so `Astro.url.searchParams` isn't available at request time). Supported keys: `trial-tips-stopped`, `subscribed`, `unsubscribed`. Any unknown or missing key falls back to the generic "Email preferences updated" message, which is also the static default so the page works without JavaScript. Raw query values are never rendered, avoiding query-parameter content injection/phishing on the rocketsim.app domain.
- The page is noindexed (`robots: index: false, follow: false` via the existing `Base`/SEO layout props, rendering `<meta name="robots" content="noindex, nofollow">`) and excluded from the sitemap.
- Fixes a pre-existing sitemap bug: the `@astrojs/sitemap` filter compared against URLs without trailing slashes, but the site uses `trailingSlash: "always"`, so none of the intended exclusions (`/terms`, `/privacy`, `/thank-you`, `/claim-offer`, etc.) were actually filtered. The filter now normalizes the trailing slash; the built sitemap no longer contains any of these pages.

## Test plan
- [x] `npm run build` passes (88 pages built)
- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] Verified `dist/emails-notify/index.html` contains `noindex, nofollow` and renders the fallback message statically
- [x] Verified `dist/sitemap-0.xml` contains no `/emails-notify` entry (and other excluded pages are now filtered too)
- [ ] After deploy, spot-check `/emails-notify?m=trial-tips-stopped`, `?m=subscribed`, `?m=unsubscribed`, and an unknown key