### PR TITLE
Update agent benchmark claims

### DIFF
--- a/docs/src/collections/feature/00-agentic-development.md
+++ b/docs/src/collections/feature/00-agentic-development.md
@@ -19,6 +19,6 @@ RocketSim ships a version-matched `rocketsim` CLI and Agent Skill so Cursor, Xco
 - Validate setup with `rocketsim doctor`
 - Keep the CLI and Agent Skill in sync through app updates
 
-In RocketSim's benchmark, the `rs/1` agent protocol produced **2.7x lower estimated token usage**, **9.7x fewer output bytes**, and **4x fewer wrong taps** overall.
+In our July 2026 head-to-head benchmark against the AXe 1.8 CLI, AXe emitted **138.8× more command output** and had a **23.4× higher byte-based context estimate**. RocketSim completed the measured command work in **32% less total time**. The context estimate is a reproducible proxy, not actual model-token or billing usage.
 
-[Read the Agentic Development docs](/docs/features/agentic-development/).
+[Read the Agentic Development docs](/docs/features/agentic-development/) or [review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-axe-1.8-and-device-hub.md).

--- a/docs/src/collections/feature/00-agentic-development.md
+++ b/docs/src/collections/feature/00-agentic-development.md
@@ -19,6 +19,6 @@ RocketSim ships a version-matched `rocketsim` CLI and Agent Skill so Cursor, Xco
 - Validate setup with `rocketsim doctor`
 - Keep the CLI and Agent Skill in sync through app updates
 
-In our July 2026 head-to-head benchmark against the AXe 1.8 CLI, AXe emitted **138.8× more command output** and had a **23.4× higher byte-based context estimate**. RocketSim completed the measured command work in **32% less total time**. The context estimate is a reproducible proxy, not actual model-token or billing usage.
+In our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**. The context estimate is a reproducible proxy, not actual model-token or billing usage.
 
-[Read the Agentic Development docs](/docs/features/agentic-development/) or [review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-axe-1.8-and-device-hub.md).
+[Read the Agentic Development docs](/docs/features/agentic-development/) or [review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-agent-workflow-benchmark.md).

--- a/docs/src/collections/feature/00-agentic-development.md
+++ b/docs/src/collections/feature/00-agentic-development.md
@@ -19,6 +19,6 @@ RocketSim ships a version-matched `rocketsim` CLI and Agent Skill so Cursor, Xco
 - Validate setup with `rocketsim doctor`
 - Keep the CLI and Agent Skill in sync through app updates
 
-In our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**. The context estimate is a reproducible proxy, not actual model-token or billing usage.
+Compared to a popular alternative in our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**. The context estimate is a reproducible proxy, not actual model-token or billing usage.
 
-[Read the Agentic Development docs](/docs/features/agentic-development/) or [review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-agent-workflow-benchmark.md).
+[Read the Agentic Development docs](/docs/features/agentic-development/).

--- a/docs/src/content/blog/ai-agents-ios-simulator/index.mdx
+++ b/docs/src/content/blog/ai-agents-ios-simulator/index.mdx
@@ -55,9 +55,9 @@ Agent workflows are sensitive to small amounts of friction. Every screen read co
 
 That is why RocketSim's CLI talks to the running Mac app instead of starting from scratch for every command. RocketSim already knows which Simulator is focused, can keep useful state warm, and can return compact `rs/1` output that is designed for agents.
 
-In our July 2026 head-to-head benchmark against the AXe 1.8 CLI, AXe emitted **138.8× more command output** and had a **23.4× higher byte-based context estimate** across current scenarios. RocketSim completed the measured command work in **32% less total time**. The AgentScenarios fixture-only subset was effectively tied at 127.2 seconds for RocketSim and 127.6 seconds for AXe, so the result does not imply that every individual workflow is faster.
+In our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**. The AgentScenarios fixture-only subset was effectively tied at 127.2 and 127.6 seconds, so the result does not imply that every individual workflow is faster.
 
-Those numbers matter because they show up directly in your day-to-day agent loop. A smaller screen summary gives the model more room to reason about the task, while lower total command time reduces waiting across a longer flow. The context estimate divides skill, prompt, and command-output bytes by four; it is a reproducible proxy, not actual model-token or billing usage. You can [review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-axe-1.8-and-device-hub.md).
+Those numbers matter because they show up directly in your day-to-day agent loop. A smaller screen summary gives the model more room to reason about the task, while lower total command time reduces waiting across a longer flow. The context estimate divides skill, prompt, and command-output bytes by four; it is a reproducible proxy, not actual model-token or billing usage. You can [review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-agent-workflow-benchmark.md).
 
 ## Accessibility elements beat screenshots
 

--- a/docs/src/content/blog/ai-agents-ios-simulator/index.mdx
+++ b/docs/src/content/blog/ai-agents-ios-simulator/index.mdx
@@ -3,6 +3,7 @@ title: "AI Agents for the iOS Simulator"
 pageTitle: "AI Agents for the iOS Simulator: Navigate Apps with RocketSim"
 description: "Let AI agents inspect, navigate, and verify iOS Simulator apps with RocketSim's CLI, Agent Skill, screenshots, and semantic interactions."
 publishedTime: 2026-06-18T18:50:00.000Z
+modifiedTime: 2026-07-24T11:15:00.000Z
 image: ./cli-agent-settings-hero.png
 imageAlt: "RocketSim CLI and Agent settings showing the Agent Skill installed for General Agents and available for Xcode, Cursor, Claude, and Codex."
 ---
@@ -54,9 +55,9 @@ Agent workflows are sensitive to small amounts of friction. Every screen read co
 
 That is why RocketSim's CLI talks to the running Mac app instead of starting from scratch for every command. RocketSim already knows which Simulator is focused, can keep useful state warm, and can return compact `rs/1` output that is designed for agents.
 
-In our internal research, RocketSim's CLI completed the same agent workflows about **19% faster**, avoided wrong taps entirely, and used about **63% fewer estimated tokens** than a popular alternative. Looking at the lower-level protocol output, the `rs/1` agent format produced **2.7x lower estimated token usage**, **9.7x fewer output bytes**, and **4x fewer wrong taps** overall.
+In our July 2026 head-to-head benchmark against the AXe 1.8 CLI, AXe emitted **138.8× more command output** and had a **23.4× higher byte-based context estimate** across current scenarios. RocketSim completed the measured command work in **32% less total time**. The AgentScenarios fixture-only subset was effectively tied at 127.2 seconds for RocketSim and 127.6 seconds for AXe, so the result does not imply that every individual workflow is faster.
 
-Those numbers matter because they show up directly in your day-to-day agent loop. A smaller screen summary gives the model more room to reason about the task, faster commands reduce waiting, and fewer wrong taps mean fewer recovery steps.
+Those numbers matter because they show up directly in your day-to-day agent loop. A smaller screen summary gives the model more room to reason about the task, while lower total command time reduces waiting across a longer flow. The context estimate divides skill, prompt, and command-output bytes by four; it is a reproducible proxy, not actual model-token or billing usage. You can [review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-axe-1.8-and-device-hub.md).
 
 ## Accessibility elements beat screenshots
 

--- a/docs/src/content/blog/ai-agents-ios-simulator/index.mdx
+++ b/docs/src/content/blog/ai-agents-ios-simulator/index.mdx
@@ -55,9 +55,9 @@ Agent workflows are sensitive to small amounts of friction. Every screen read co
 
 That is why RocketSim's CLI talks to the running Mac app instead of starting from scratch for every command. RocketSim already knows which Simulator is focused, can keep useful state warm, and can return compact `rs/1` output that is designed for agents.
 
-In our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**. The AgentScenarios fixture-only subset was effectively tied at 127.2 and 127.6 seconds, so the result does not imply that every individual workflow is faster.
+Compared to a popular alternative in our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**. The AgentScenarios fixture-only subset was effectively tied at 127.2 and 127.6 seconds, so the result does not imply that every individual workflow is faster.
 
-Those numbers matter because they show up directly in your day-to-day agent loop. A smaller screen summary gives the model more room to reason about the task, while lower total command time reduces waiting across a longer flow. The context estimate divides skill, prompt, and command-output bytes by four; it is a reproducible proxy, not actual model-token or billing usage. You can [review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-agent-workflow-benchmark.md).
+Those numbers matter because they show up directly in your day-to-day agent loop. A smaller screen summary gives the model more room to reason about the task, while lower total command time reduces waiting across a longer flow. The context estimate divides skill, prompt, and command-output bytes by four; it is a reproducible proxy, not actual model-token or billing usage.
 
 ## Accessibility elements beat screenshots
 

--- a/docs/src/content/docs/docs/features/agentic-development/agent-skill.md
+++ b/docs/src/content/docs/docs/features/agentic-development/agent-skill.md
@@ -24,7 +24,7 @@ The skill helps agents:
 - Use screenshots when accessibility data is sparse or incomplete
 - Run `rocketsim doctor` when setup needs to be checked
 
-In our internal research, RocketSim's CLI completed the same agent workflows about **19% faster, avoided wrong taps entirely**, and used about **63% fewer estimated tokens** than a popular alternative.
+In our July 2026 head-to-head benchmark against the AXe 1.8 CLI, AXe emitted **138.8× more command output** and had a **23.4× higher byte-based context estimate** across current scenarios. RocketSim completed the measured command work in **32% less total time**. The context estimate divides skill, prompt, and command-output bytes by four; it is not actual model-token or billing usage. [Review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-axe-1.8-and-device-hub.md).
 
 ## Install from RocketSim
 

--- a/docs/src/content/docs/docs/features/agentic-development/agent-skill.md
+++ b/docs/src/content/docs/docs/features/agentic-development/agent-skill.md
@@ -24,7 +24,7 @@ The skill helps agents:
 - Use screenshots when accessibility data is sparse or incomplete
 - Run `rocketsim doctor` when setup needs to be checked
 
-In our July 2026 head-to-head benchmark against the AXe 1.8 CLI, AXe emitted **138.8× more command output** and had a **23.4× higher byte-based context estimate** across current scenarios. RocketSim completed the measured command work in **32% less total time**. The context estimate divides skill, prompt, and command-output bytes by four; it is not actual model-token or billing usage. [Review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-axe-1.8-and-device-hub.md).
+In our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**. The context estimate divides skill, prompt, and command-output bytes by four; it is not actual model-token or billing usage. [Review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-agent-workflow-benchmark.md).
 
 ## Install from RocketSim
 

--- a/docs/src/content/docs/docs/features/agentic-development/agent-skill.md
+++ b/docs/src/content/docs/docs/features/agentic-development/agent-skill.md
@@ -24,7 +24,7 @@ The skill helps agents:
 - Use screenshots when accessibility data is sparse or incomplete
 - Run `rocketsim doctor` when setup needs to be checked
 
-In our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**. The context estimate divides skill, prompt, and command-output bytes by four; it is not actual model-token or billing usage. [Review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-agent-workflow-benchmark.md).
+Compared to a popular alternative in our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**. The context estimate divides skill, prompt, and command-output bytes by four; it is not actual model-token or billing usage.
 
 ## Install from RocketSim
 

--- a/docs/src/content/docs/docs/features/agentic-development/index.md
+++ b/docs/src/content/docs/docs/features/agentic-development/index.md
@@ -61,7 +61,9 @@ Try these with any AI coding tool that has the RocketSim Agent Skill installed:
 
 ### Stateful by design
 
-RocketSim runs continuously alongside the Simulator. Because there is already a Mac app watching the active device, RocketSim can reuse state, cache expensive work, and optimize repeated agent loops in ways one-off commands cannot. In our internal research, RocketSim's CLI completed the same agent workflows about **19% faster, avoided wrong taps entirely**, and used about **63% fewer estimated tokens** than a popular alternative.
+RocketSim runs continuously alongside the Simulator. Because there is already a Mac app watching the active device, RocketSim can reuse state, cache expensive work, and optimize repeated agent loops in ways one-off commands cannot. In our July 2026 head-to-head benchmark against the AXe 1.8 CLI, AXe emitted **138.8× more command output** and had a **23.4× higher byte-based context estimate** across current scenarios. RocketSim completed the measured command work in **32% less total time**, while AgentScenarios fixture-only time was effectively tied at 127.2 seconds for RocketSim and 127.6 seconds for AXe.
+
+The context estimate divides skill, prompt, and command-output bytes by four. It is a reproducible comparison proxy, not actual model-token or billing usage. [Review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-axe-1.8-and-device-hub.md).
 
 ### Compact screen summaries
 

--- a/docs/src/content/docs/docs/features/agentic-development/index.md
+++ b/docs/src/content/docs/docs/features/agentic-development/index.md
@@ -61,9 +61,9 @@ Try these with any AI coding tool that has the RocketSim Agent Skill installed:
 
 ### Stateful by design
 
-RocketSim runs continuously alongside the Simulator. Because there is already a Mac app watching the active device, RocketSim can reuse state, cache expensive work, and optimize repeated agent loops in ways one-off commands cannot. In our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**.
+RocketSim runs continuously alongside the Simulator. Because there is already a Mac app watching the active device, RocketSim can reuse state, cache expensive work, and optimize repeated agent loops in ways one-off commands cannot. Compared to a popular alternative in our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**.
 
-The AgentScenarios fixture-only subset was effectively tied at 127.2 and 127.6 seconds, so the result does not imply that every individual workflow is faster. The context estimate divides skill, prompt, and command-output bytes by four. It is a reproducible comparison proxy, not actual model-token or billing usage. [Review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-agent-workflow-benchmark.md).
+The AgentScenarios fixture-only subset was effectively tied at 127.2 and 127.6 seconds, so the result does not imply that every individual workflow is faster. The context estimate divides skill, prompt, and command-output bytes by four. It is a reproducible comparison proxy, not actual model-token or billing usage.
 
 ### Compact screen summaries
 

--- a/docs/src/content/docs/docs/features/agentic-development/index.md
+++ b/docs/src/content/docs/docs/features/agentic-development/index.md
@@ -61,9 +61,9 @@ Try these with any AI coding tool that has the RocketSim Agent Skill installed:
 
 ### Stateful by design
 
-RocketSim runs continuously alongside the Simulator. Because there is already a Mac app watching the active device, RocketSim can reuse state, cache expensive work, and optimize repeated agent loops in ways one-off commands cannot. In our July 2026 head-to-head benchmark against the AXe 1.8 CLI, AXe emitted **138.8× more command output** and had a **23.4× higher byte-based context estimate** across current scenarios. RocketSim completed the measured command work in **32% less total time**, while AgentScenarios fixture-only time was effectively tied at 127.2 seconds for RocketSim and 127.6 seconds for AXe.
+RocketSim runs continuously alongside the Simulator. Because there is already a Mac app watching the active device, RocketSim can reuse state, cache expensive work, and optimize repeated agent loops in ways one-off commands cannot. In our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**.
 
-The context estimate divides skill, prompt, and command-output bytes by four. It is a reproducible comparison proxy, not actual model-token or billing usage. [Review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-axe-1.8-and-device-hub.md).
+The AgentScenarios fixture-only subset was effectively tied at 127.2 and 127.6 seconds, so the result does not imply that every individual workflow is faster. The context estimate divides skill, prompt, and command-output bytes by four. It is a reproducible comparison proxy, not actual model-token or billing usage. [Review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-agent-workflow-benchmark.md).
 
 ### Compact screen summaries
 

--- a/docs/src/content/docs/docs/features/agentic-development/rocketsim-cli.md
+++ b/docs/src/content/docs/docs/features/agentic-development/rocketsim-cli.md
@@ -43,9 +43,9 @@ RocketSim is not just a standalone command that starts from scratch every time. 
 
 The CLI uses RocketSim's `rs/1` protocol for agent workflows. You do not need to learn the protocol details; it is the compact, agent-optimized layer that lets RocketSim provide reliable screen reads, interaction feedback, and recovery paths while keeping output small.
 
-In our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**.
+Compared to a popular alternative in our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**.
 
-The AgentScenarios fixture-only subset was effectively tied at 127.2 and 127.6 seconds, so the result does not imply that every individual workflow is faster. The context estimate divides skill, prompt, and command-output bytes by four. It is a reproducible comparison proxy, not actual model-token or billing usage. [Review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-agent-workflow-benchmark.md).
+The AgentScenarios fixture-only subset was effectively tied at 127.2 and 127.6 seconds, so the result does not imply that every individual workflow is faster. The context estimate divides skill, prompt, and command-output bytes by four. It is a reproducible comparison proxy, not actual model-token or billing usage.
 
 ## Key commands
 

--- a/docs/src/content/docs/docs/features/agentic-development/rocketsim-cli.md
+++ b/docs/src/content/docs/docs/features/agentic-development/rocketsim-cli.md
@@ -43,7 +43,9 @@ RocketSim is not just a standalone command that starts from scratch every time. 
 
 The CLI uses RocketSim's `rs/1` protocol for agent workflows. You do not need to learn the protocol details; it is the compact, agent-optimized layer that lets RocketSim provide reliable screen reads, interaction feedback, and recovery paths while keeping output small.
 
-In our internal research, RocketSim's CLI completed the same agent workflows about **19% faster, avoided wrong taps entirely**, and used about **63% fewer estimated tokens** than a popular alternative.
+In our July 2026 head-to-head benchmark against the AXe 1.8 CLI, AXe emitted **138.8× more command output** and had a **23.4× higher byte-based context estimate** across current scenarios. RocketSim completed the measured command work in **32% less total time**, while AgentScenarios fixture-only time was effectively tied at 127.2 seconds for RocketSim and 127.6 seconds for AXe.
+
+The context estimate divides skill, prompt, and command-output bytes by four. It is a reproducible comparison proxy, not actual model-token or billing usage. [Review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-axe-1.8-and-device-hub.md).
 
 ## Key commands
 
@@ -204,7 +206,7 @@ Use `--touches 2` or `--number-of-touches 2` with `tap` or `long-press` to autom
 
 ## Why `--agent` matters
 
-The `--agent` flag reduces the element output from full JSON to a compact pipe-delimited format. That means fewer tokens per screen read, faster agent decision loops, and easier recovery after each interaction.
+The `--agent` flag reduces the element output from full JSON to a compact pipe-delimited format. That means less context per screen read and easier recovery after each interaction.
 
 Here is the same screen in both formats:
 

--- a/docs/src/content/docs/docs/features/agentic-development/rocketsim-cli.md
+++ b/docs/src/content/docs/docs/features/agentic-development/rocketsim-cli.md
@@ -43,9 +43,9 @@ RocketSim is not just a standalone command that starts from scratch every time. 
 
 The CLI uses RocketSim's `rs/1` protocol for agent workflows. You do not need to learn the protocol details; it is the compact, agent-optimized layer that lets RocketSim provide reliable screen reads, interaction feedback, and recovery paths while keeping output small.
 
-In our July 2026 head-to-head benchmark against the AXe 1.8 CLI, AXe emitted **138.8× more command output** and had a **23.4× higher byte-based context estimate** across current scenarios. RocketSim completed the measured command work in **32% less total time**, while AgentScenarios fixture-only time was effectively tied at 127.2 seconds for RocketSim and 127.6 seconds for AXe.
+In our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**.
 
-The context estimate divides skill, prompt, and command-output bytes by four. It is a reproducible comparison proxy, not actual model-token or billing usage. [Review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-axe-1.8-and-device-hub.md).
+The AgentScenarios fixture-only subset was effectively tied at 127.2 and 127.6 seconds, so the result does not imply that every individual workflow is faster. The context estimate divides skill, prompt, and command-output bytes by four. It is a reproducible comparison proxy, not actual model-token or billing usage. [Review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-agent-workflow-benchmark.md).
 
 ## Key commands
 

--- a/docs/src/content/docs/docs/settings/cli-and-agent.md
+++ b/docs/src/content/docs/docs/settings/cli-and-agent.md
@@ -49,7 +49,7 @@ Use a tool-specific destination only if your tool does not scan the shared locat
 
 The RocketSim Mac app is already running beside the Simulator. It can keep state, cache expensive work, and optimize repeated agent loops. The CLI exposes that running app to agents, and the Agent Skill helps agents use the CLI in the right order.
 
-In our internal research, RocketSim's CLI completed the same agent workflows about **19% faster, avoided wrong taps entirely**, and used about **63% fewer estimated tokens** than a popular alternative.
+In our July 2026 head-to-head benchmark against the AXe 1.8 CLI, AXe emitted **138.8× more command output** and had a **23.4× higher byte-based context estimate** across current scenarios. RocketSim completed the measured command work in **32% less total time**. The context estimate divides skill, prompt, and command-output bytes by four; it is not actual model-token or billing usage. [Review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-axe-1.8-and-device-hub.md).
 
 ## Verify the setup
 

--- a/docs/src/content/docs/docs/settings/cli-and-agent.md
+++ b/docs/src/content/docs/docs/settings/cli-and-agent.md
@@ -49,7 +49,7 @@ Use a tool-specific destination only if your tool does not scan the shared locat
 
 The RocketSim Mac app is already running beside the Simulator. It can keep state, cache expensive work, and optimize repeated agent loops. The CLI exposes that running app to agents, and the Agent Skill helps agents use the CLI in the right order.
 
-In our July 2026 head-to-head benchmark against the AXe 1.8 CLI, AXe emitted **138.8× more command output** and had a **23.4× higher byte-based context estimate** across current scenarios. RocketSim completed the measured command work in **32% less total time**. The context estimate divides skill, prompt, and command-output bytes by four; it is not actual model-token or billing usage. [Review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-axe-1.8-and-device-hub.md).
+In our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**. The context estimate divides skill, prompt, and command-output bytes by four; it is not actual model-token or billing usage. [Review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-agent-workflow-benchmark.md).
 
 ## Verify the setup
 

--- a/docs/src/content/docs/docs/settings/cli-and-agent.md
+++ b/docs/src/content/docs/docs/settings/cli-and-agent.md
@@ -49,7 +49,7 @@ Use a tool-specific destination only if your tool does not scan the shared locat
 
 The RocketSim Mac app is already running beside the Simulator. It can keep state, cache expensive work, and optimize repeated agent loops. The CLI exposes that running app to agents, and the Agent Skill helps agents use the CLI in the right order.
 
-In our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**. The context estimate divides skill, prompt, and command-output bytes by four; it is not actual model-token or billing usage. [Review the benchmark methodology and results](https://github.com/AvdLee/RocketSim/blob/master/docs/agent-protocol/eval/2026-07-24-agent-workflow-benchmark.md).
+Compared to a popular alternative in our July 2026 head-to-head benchmark, RocketSim produced **over 99% less command output**, had an **approximately 96% lower byte-based context estimate**, and completed the measured command work in **32% less total time**. The context estimate divides skill, prompt, and command-output bytes by four; it is not actual model-token or billing usage.
 
 ## Verify the setup
 


### PR DESCRIPTION
## Summary
- replace the April agent benchmark claims across the homepage, blog, CLI/Agent settings, and agentic-development documentation with the verified July 2026 comparison to a popular alternative
- lead with RocketSim's customer-facing gains: over 99% less command output, an approximately 96% lower byte-based context estimate, and 32% less total command time
- remove unsupported wrong-tap claims, disclose that AgentScenarios fixture-only timing was effectively tied, and define the context estimate as a reproducible proxy rather than tokenizer or billing usage
- keep the comparison anonymous and avoid linking the public website to private benchmark materials

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run knip`
- [x] verified updated claims in generated homepage, docs, blog, and LLM exports