### PR TITLE
Recover the Teams trial funnel with an embedded signup form

### DIFF
--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -6,6 +6,8 @@ event only when tracking a genuinely new action.
 
 ## Existing Teams events
 
+- `CTA: Homepage Hero - For Teams` opens `/for-teams/` from the homepage
+  hero. This historical event was restored after the Teams link returned.
 - `CTA: Homepage Insights - Learn More` opens `/for-teams`.
 - `CTA: Homepage Mid 2 - Trial` opens `/for-teams`. The historical name says
   "Trial," but the action only opens Teams information. Keep the event name and
@@ -23,6 +25,18 @@ event only when tracking a genuinely new action.
 - `CTA: Blog Bottom - Trial` opens the Teams trial form from a blog post's
   bottom call-to-action.
 
+## Inline trial form events
+
+- `Teams Trial Form Started` fires once when a visitor first interacts with the
+  inline form on `/for-teams/`.
+- `Teams Trial Signup Submitted` fires when the inline form is submitted.
+- `CTA: Team Page - Start Trial` also fires on inline form submission to
+  preserve the historical series.
+
+These events include `surface`, `placement`, `format`, and `source`. Submission
+events include a coarse `team_size` bucket. Never send names, email addresses,
+or exact team sizes to Plausible.
+
 ## Trial completion
 
 Configure `/signup/trial/thank-you/` as a Plausible pageview goal. The page is
@@ -31,3 +45,29 @@ preserves historical data without introducing another custom event.
 
 The goal is directional until `www.rocketsim.app` and `teams.rocketsim.app`
 have been verified to use the same Plausible site ID and script.
+
+## Paid conversion
+
+`Teams Trial Converted` fires once per browser session when a successful Stripe
+trial upgrade lands on the LicenseKit trial-upgrade success page. Configure it
+as a Plausible custom-event goal and use unique visitors rather than raw events
+for reporting.
+
+## Four-week recovery measurement
+
+Use the 30 completed days ending July 23, 2026 as the pre-change baseline:
+
+- `/for-teams/`: 128 unique visitors.
+- `Teams Trial Signup Completed`: 5 unique visitors.
+- Homepage `App Store Install`: 14.23% conversion during the equal 32-day
+  post-May-27 comparison period.
+
+After four complete weeks, compare unique visitors and conversion rates against
+an equal-length period:
+
+1. Target at least 200 monthly-equivalent visitors to `/for-teams/`.
+2. Target 12–18 monthly-equivalent unique completed trials.
+3. Separate inline hero submissions from pricing CTA visitors using placement.
+4. Report `Teams Trial Converted` as the final business outcome.
+5. Treat homepage App Store install conversion as a guardrail. Investigate if
+   it declines by more than 5% relative to the 14.23% baseline.

--- a/docs/src/components/TeamsTrialForm.astro
+++ b/docs/src/components/TeamsTrialForm.astro
@@ -1,0 +1,376 @@
+---
+import config from "@/config/config.json";
+
+// In dev, post to the local LicenseKit server so the whole trial flow can be
+// tested without touching production.
+const teamsBaseUrl = import.meta.env.DEV
+  ? "http://localhost:5173"
+  : config.site.teams_base_url;
+
+const trialAction = `${teamsBaseUrl}/api/signup/trial?utm_source=website&utm_medium=website&utm_content=for_teams_hero_form`;
+---
+
+<style>
+  .trial-card {
+    width: 100%;
+    padding: 1.5rem;
+
+    background: #101010;
+    border: 0.0625rem solid rgb(255 255 255 / 12%);
+    border-radius: 1rem;
+  }
+
+  .trial-card__eyebrow {
+    margin: 0 0 0.375rem;
+
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--primary-color);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .trial-card h2 {
+    margin: 0;
+
+    font-size: 1.375rem;
+    font-weight: 600;
+    color: #fff;
+  }
+
+  .trial-card__intro {
+    margin: 0.5rem 0 1.25rem;
+
+    font-size: 0.875rem;
+    color: var(--text-color);
+  }
+
+  .trial-form {
+    display: grid;
+    gap: 0.875rem;
+  }
+
+  .trial-form__field {
+    display: grid;
+    gap: 0.375rem;
+  }
+
+  .trial-form label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--text-color-light);
+  }
+
+  .trial-form input {
+    width: 100%;
+    padding: 0.75rem 0.875rem;
+
+    font: inherit;
+    color: #fff;
+
+    background: #050505;
+    border: 0.0625rem solid rgb(255 255 255 / 18%);
+    border-radius: 0.5rem;
+  }
+
+  .trial-form input::placeholder {
+    color: #777;
+  }
+
+  .trial-form input:focus-visible {
+    border-color: var(--primary-color);
+    outline: 0.0625rem solid var(--ring);
+    outline-offset: 0.0625rem;
+  }
+
+  .trial-form input[aria-invalid="true"] {
+    border-color: #ff7b7b;
+  }
+
+  .trial-form__error {
+    margin: 0;
+
+    font-size: 0.75rem;
+    color: #ff9b9b;
+    line-height: 1.4;
+  }
+
+  .trial-form__submit {
+    width: 100%;
+    margin-top: 0.25rem;
+    border: 0;
+    cursor: pointer;
+  }
+
+  .trial-form__submit:disabled {
+    cursor: wait;
+    opacity: 0.7;
+  }
+
+  .trial-form__trust {
+    margin: 0;
+
+    font-size: 0.75rem;
+    color: #888;
+    line-height: 1.5;
+    text-align: center;
+  }
+
+  .trial-form__pricing {
+    display: block;
+    margin-top: 1rem;
+
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--primary-color);
+    text-align: center;
+    text-decoration: none;
+  }
+
+  .trial-form__pricing:hover {
+    text-decoration: underline;
+  }
+
+  .trial-form__pricing:focus-visible {
+    border-radius: 0.25rem;
+    outline: 0.125rem solid var(--ring);
+  }
+</style>
+
+<div class="trial-card">
+  <p class="trial-card__eyebrow">14-day free trial</p>
+  <h2>Start with your team</h2>
+  <p class="trial-card__intro">Use your work email. No credit card required.</p>
+  <form
+    class="trial-form"
+    action={trialAction}
+    method="post"
+    data-teams-trial-form
+  >
+    <div class="trial-form__field">
+      <label for="teams-trial-email">Work email</label>
+      <input
+        id="teams-trial-email"
+        name="email"
+        type="email"
+        autocomplete="email"
+        placeholder="you@company.com"
+        aria-describedby="teams-trial-email-error"
+        required
+      />
+      <p
+        class="trial-form__error"
+        id="teams-trial-email-error"
+        data-trial-error="email"
+        hidden
+      >
+      </p>
+    </div>
+    <div class="trial-form__field">
+      <label for="teams-trial-name">Full name</label>
+      <input
+        id="teams-trial-name"
+        name="full_name"
+        type="text"
+        autocomplete="name"
+        placeholder="Your name"
+        aria-describedby="teams-trial-name-error"
+        required
+      />
+      <p
+        class="trial-form__error"
+        id="teams-trial-name-error"
+        data-trial-error="full_name"
+        hidden
+      >
+      </p>
+    </div>
+    <div class="trial-form__field">
+      <label for="teams-trial-size">Number of iOS developers</label>
+      <input
+        id="teams-trial-size"
+        name="trial_team_size"
+        type="number"
+        inputmode="numeric"
+        min="1"
+        max="1000"
+        placeholder="5"
+        aria-describedby="teams-trial-size-error"
+        required
+      />
+      <p
+        class="trial-form__error"
+        id="teams-trial-size-error"
+        data-trial-error="trial_team_size"
+        hidden
+      >
+      </p>
+    </div>
+    <p
+      class="trial-form__error"
+      data-trial-error="composite"
+      role="alert"
+      aria-live="polite"
+      hidden
+    >
+    </p>
+    <button class="button trial-form__submit" type="submit">
+      Start free Teams trial
+    </button>
+    <p class="trial-form__trust">
+      One shared license key. Essential setup and expiry emails are included.
+    </p>
+  </form>
+  <a
+    class="trial-form__pricing plausible-event-name=CTA:+Team+Page+-+See+Pricing plausible-event-surface=for-teams plausible-event-placement=for-teams-hero plausible-event-format=text-link plausible-event-source=website"
+    href="/pricing/#plan-teams"
+  >
+    Compare team pricing &rarr;
+  </a>
+</div>
+
+<script>
+  type TrialErrorType =
+    "email" | "business_email" | "full_name" | "trial_team_size" | "composite";
+
+  type TrialResponse = {
+    error?: {
+      type: TrialErrorType;
+      message: string;
+    };
+    redirectUrl?: string;
+  };
+
+  const teamsTrialFormInit = () => {
+    const form = document.querySelector("[data-teams-trial-form]");
+    if (!(form instanceof HTMLFormElement)) return;
+    if (form.dataset.initialized === "true") return;
+    form.dataset.initialized = "true";
+
+    const track = (eventName: string, props: Record<string, string>) => {
+      const plausible = (
+        window as Window & {
+          plausible?: (
+            eventName: string,
+            options?: { props?: Record<string, string> },
+          ) => void;
+        }
+      ).plausible;
+
+      plausible?.(eventName, { props });
+    };
+
+    const baseProps = {
+      surface: "for-teams",
+      placement: "for-teams-hero",
+      format: "inline-form",
+      source: "website",
+    };
+    let hasTrackedInteraction = false;
+
+    const clearErrors = () => {
+      form
+        .querySelectorAll<HTMLInputElement>("[aria-invalid]")
+        .forEach((input) => input.removeAttribute("aria-invalid"));
+      form
+        .querySelectorAll<HTMLElement>("[data-trial-error]")
+        .forEach((errorElement) => {
+          errorElement.hidden = true;
+          errorElement.textContent = "";
+        });
+    };
+
+    const showError = (type: TrialErrorType, message: string) => {
+      const fieldName = type === "business_email" ? "email" : type;
+      const errorElement = form.querySelector<HTMLElement>(
+        `[data-trial-error="${fieldName}"]`,
+      );
+      if (!errorElement) return;
+
+      errorElement.textContent = message;
+      errorElement.hidden = false;
+
+      const input = form.elements.namedItem(fieldName);
+      if (input instanceof HTMLInputElement) {
+        input.setAttribute("aria-invalid", "true");
+        input.focus();
+      }
+    };
+
+    form.addEventListener("focusin", () => {
+      if (hasTrackedInteraction) return;
+      hasTrackedInteraction = true;
+      track("Teams Trial Form Started", baseProps);
+    });
+
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      clearErrors();
+
+      const teamSizeInput = form.elements.namedItem("trial_team_size");
+      const teamSize =
+        teamSizeInput instanceof HTMLInputElement
+          ? Number(teamSizeInput.value)
+          : 0;
+      const teamSizeBucket =
+        teamSize <= 5
+          ? "1-5"
+          : teamSize <= 10
+            ? "6-10"
+            : teamSize <= 25
+              ? "11-25"
+              : teamSize <= 50
+                ? "26-50"
+                : "51+";
+      const props = { ...baseProps, team_size: teamSizeBucket };
+
+      track("Teams Trial Signup Submitted", props);
+      track("CTA: Team Page - Start Trial", props);
+
+      const submitButton = form.querySelector<HTMLButtonElement>(
+        ".trial-form__submit",
+      );
+      const submitLabel = submitButton?.textContent;
+      if (submitButton) {
+        submitButton.disabled = true;
+        submitButton.textContent = "Starting trial…";
+      }
+
+      try {
+        const response = await fetch(form.action, {
+          method: "POST",
+          headers: { Accept: "application/json" },
+          body: new FormData(form),
+        });
+        const payload = (await response.json()) as TrialResponse;
+
+        if (response.ok && payload.redirectUrl) {
+          window.location.assign(payload.redirectUrl);
+          return;
+        }
+
+        if (payload.error) {
+          showError(payload.error.type, payload.error.message);
+          return;
+        }
+
+        showError(
+          "composite",
+          "We couldn't start your trial. Please try again.",
+        );
+      } catch {
+        showError(
+          "composite",
+          "We couldn't start your trial. Please try again.",
+        );
+      } finally {
+        if (submitButton) {
+          submitButton.disabled = false;
+          submitButton.textContent = submitLabel ?? "Start free Teams trial";
+        }
+      }
+    });
+  };
+
+  document.addEventListener("astro:page-load", teamsTrialFormInit);
+</script>

--- a/docs/src/components/TeamsTrialForm.astro
+++ b/docs/src/components/TeamsTrialForm.astro
@@ -231,7 +231,11 @@ const trialAction = `${teamsBaseUrl}/api/signup/trial?utm_source=website&utm_med
 
 <script>
   type TrialErrorType =
-    "email" | "business_email" | "full_name" | "trial_team_size" | "composite";
+    | "email"
+    | "business_email"
+    | "full_name"
+    | "trial_team_size"
+    | "composite";
 
   type TrialResponse = {
     error?: {

--- a/docs/src/components/TeamsTrialForm.astro
+++ b/docs/src/components/TeamsTrialForm.astro
@@ -237,12 +237,41 @@ const trialAction = `${teamsBaseUrl}/api/signup/trial?utm_source=website&utm_med
     | "trial_team_size"
     | "composite";
 
-  type TrialResponse = {
-    error?: {
-      type: TrialErrorType;
-      message: string;
-    };
-    redirectUrl?: string;
+  type TrialError = {
+    type: TrialErrorType;
+    message: string;
+  };
+
+  // Response contract of the LicenseKit /api/signup/trial endpoint. Keep in
+  // sync with TrialApiResponse in LicenseKit's api.signup.trial route.
+  type TrialResponse = { error: TrialError } | { redirectUrl: string };
+
+  declare global {
+    interface Window {
+      plausible?: (
+        eventName: string,
+        options?: { props?: Record<string, string> },
+      ) => void;
+    }
+  }
+
+  const isTrialResponse = (payload: unknown): payload is TrialResponse => {
+    if (typeof payload !== "object" || payload === null) return false;
+    if ("redirectUrl" in payload) {
+      return typeof payload.redirectUrl === "string";
+    }
+    if ("error" in payload) {
+      const error = payload.error;
+      return (
+        typeof error === "object" &&
+        error !== null &&
+        "type" in error &&
+        typeof error.type === "string" &&
+        "message" in error &&
+        typeof error.message === "string"
+      );
+    }
+    return false;
   };
 
   const teamsTrialFormInit = () => {
@@ -252,16 +281,7 @@ const trialAction = `${teamsBaseUrl}/api/signup/trial?utm_source=website&utm_med
     form.dataset.initialized = "true";
 
     const track = (eventName: string, props: Record<string, string>) => {
-      const plausible = (
-        window as Window & {
-          plausible?: (
-            eventName: string,
-            options?: { props?: Record<string, string> },
-          ) => void;
-        }
-      ).plausible;
-
-      plausible?.(eventName, { props });
+      window.plausible?.(eventName, { props });
     };
 
     const baseProps = {
@@ -284,11 +304,12 @@ const trialAction = `${teamsBaseUrl}/api/signup/trial?utm_source=website&utm_med
         });
     };
 
-    const showError = (type: TrialErrorType, message: string) => {
+    const showError = (type: string, message: string) => {
       const fieldName = type === "business_email" ? "email" : type;
-      const errorElement = form.querySelector<HTMLElement>(
-        `[data-trial-error="${fieldName}"]`,
-      );
+      const errorElement =
+        form.querySelector<HTMLElement>(`[data-trial-error="${fieldName}"]`) ??
+        // Unknown error types still need to surface something to the visitor.
+        form.querySelector<HTMLElement>('[data-trial-error="composite"]');
       if (!errorElement) return;
 
       errorElement.textContent = message;
@@ -307,8 +328,12 @@ const trialAction = `${teamsBaseUrl}/api/signup/trial?utm_source=website&utm_med
       track("Teams Trial Form Started", baseProps);
     });
 
+    let isSubmitting = false;
+
     form.addEventListener("submit", async (event) => {
       event.preventDefault();
+      if (isSubmitting) return;
+      isSubmitting = true;
       clearErrors();
 
       const teamSizeInput = form.elements.namedItem("trial_team_size");
@@ -340,20 +365,33 @@ const trialAction = `${teamsBaseUrl}/api/signup/trial?utm_source=website&utm_med
         submitButton.textContent = "Starting trial…";
       }
 
+      let isRedirecting = false;
+
       try {
         const response = await fetch(form.action, {
           method: "POST",
           headers: { Accept: "application/json" },
           body: new FormData(form),
         });
-        const payload = (await response.json()) as TrialResponse;
+        const payload: unknown = await response.json();
 
-        if (response.ok && payload.redirectUrl) {
+        if (!isTrialResponse(payload)) {
+          showError(
+            "composite",
+            "We couldn't start your trial. Please try again.",
+          );
+          return;
+        }
+
+        if ("redirectUrl" in payload && response.ok) {
+          // Keep the form disabled while the browser navigates away, so the
+          // trial can't be submitted twice.
+          isRedirecting = true;
           window.location.assign(payload.redirectUrl);
           return;
         }
 
-        if (payload.error) {
+        if ("error" in payload) {
           showError(payload.error.type, payload.error.message);
           return;
         }
@@ -368,9 +406,12 @@ const trialAction = `${teamsBaseUrl}/api/signup/trial?utm_source=website&utm_med
           "We couldn't start your trial. Please try again.",
         );
       } finally {
-        if (submitButton) {
-          submitButton.disabled = false;
-          submitButton.textContent = submitLabel ?? "Start free Teams trial";
+        if (!isRedirecting) {
+          isSubmitting = false;
+          if (submitButton) {
+            submitButton.disabled = false;
+            submitButton.textContent = submitLabel ?? "Start free Teams trial";
+          }
         }
       }
     });

--- a/docs/src/content/sections/pricing.md
+++ b/docs/src/content/sections/pricing.md
@@ -90,7 +90,7 @@ plans:
       label: Start 14-day Trial
       site: teams
       link: "/signup/trial?utm_source=website&utm_medium=website&utm_content=pricing"
-      class: "plausible-event-name=CTA:+Pricing+Teams+-+Trial"
+      class: "plausible-event-name=CTA:+Pricing+Teams+-+Trial plausible-event-surface=pricing plausible-event-placement=pricing-teams-card plausible-event-format=button plausible-event-source=website"
   - enable: true
     title: Enterprise
     description: For larger organizations that need more control, security, custom distribution, and rollout support.

--- a/docs/src/old/components/Header.astro
+++ b/docs/src/old/components/Header.astro
@@ -10,6 +10,7 @@ interface Props {
 }
 
 const { title, logo, logoAlt } = Astro.props;
+const hasAside = Astro.slots.has("aside");
 ---
 
 <style>
@@ -67,7 +68,7 @@ const { title, logo, logoAlt } = Astro.props;
     margin: 0 0 1rem;
   }
 
-  .hero__logo {
+  .hero__aside {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -108,14 +109,20 @@ const { title, logo, logoAlt } = Astro.props;
         <slot />
       </p>
     </div>
-    <div class="hero__logo">
-      <Image
-        src={appIcon}
-        widths={[128, 512]}
-        sizes="(max-width: 767px) 4rem, 16rem"
-        alt="RocketSim app icon"
-        class="logo-image"
-      />
+    <div class="hero__aside">
+      {
+        hasAside ? (
+          <slot name="aside" />
+        ) : (
+          <Image
+            src={appIcon}
+            widths={[128, 512]}
+            sizes="(max-width: 767px) 4rem, 16rem"
+            alt="RocketSim app icon"
+            class="logo-image"
+          />
+        )
+      }
     </div>
   </div>
 </header>

--- a/docs/src/pages/for-teams.astro
+++ b/docs/src/pages/for-teams.astro
@@ -3,8 +3,7 @@ import { getEntry } from "astro:content";
 
 import config from "@/config/config.json";
 import Base from "@/layouts/Base.astro";
-import Navigation from "../old/components/Navigation.astro";
-import NavigationLink from "../old/components/NavigationLink.astro";
+import TeamsTrialForm from "../components/TeamsTrialForm.astro";
 import Header from "../old/components/Header.astro";
 import Insights from "../old/components/Insights.astro";
 import InsightsBreakdown from "../old/components/InsightsBreakdown.astro";
@@ -41,25 +40,11 @@ const structuredData = {
 ---
 
 <Base seo={seo} structuredData={structuredData}>
-  <Header title="Make your whole team Build Apps Faster">
-    Connect your team using the same license key and gather team insights like
-    p75 build duration, machine benchmarks, and more.
+  <Header title="Turn local Xcode builds into decisions backed by data">
+    Compare build duration by machine, Xcode version, project, and scheme —
+    without adding build phases, scripts, or dashboards to maintain.
+    <TeamsTrialForm slot="aside" />
   </Header>
-  <Navigation showLogin>
-    <NavigationLink
-      href="/pricing/"
-      asButton
-      className="plausible-event-name=CTA:+Team+Page+-+See+Pricing"
-    >
-      See Team Pricing &rarr;
-    </NavigationLink>
-    <NavigationLink
-      href="https://teams.rocketsim.app/signup/trial?utm_source=website&utm_medium=website&utm_content=for_teams_hero"
-      className="plausible-event-name=CTA:+Team+Page+-+Start+Trial"
-    >
-      Start 14-Day Trial
-    </NavigationLink>
-  </Navigation>
   <TrustedBrands />
   <TeamTestimonial />
   <Insights />

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -82,6 +82,13 @@ const structuredData = {
       Free download
     </NavigationLink>
     <NavigationLink
+      href="/for-teams/"
+      className="plausible-event-name=CTA:+Homepage+Hero+-+For+Teams"
+      asSecondaryButton
+    >
+      For Teams
+    </NavigationLink>
+    <NavigationLink
       href="/features/"
       className="plausible-event-name=CTA:+Homepage+Hero+-+Features"
       >Explore features &rarr;</NavigationLink


### PR DESCRIPTION
## Summary
- Restores the secondary "For Teams" button on the homepage hero (removed May 27), which correlated with a sharp drop in For Teams traffic and trial completions
- Embeds a native three-field Teams trial form directly in the For Teams hero: it posts to the LicenseKit JSON API (`/api/signup/trial`), shows inline validation errors under each field, and only navigates away on success
- In dev the form posts to the local LicenseKit server (`localhost:5173`); production posts to `teams.rocketsim.app`
- Hero and form copy aligned with the product-marketing positioning
- Funnel tracking: `Teams Trial Form Started` / form submission events with source attribution properties (no PII), documented in `ANALYTICS.md`

## Dependencies
- LicenseKit API route is live in production (#787)
- AvdLee/LicenseKit#790 fixes the thank-you redirect (trailing slash + www) — merge that before or shortly after this ships

## Test plan
- [x] Full local flow validated: form → local LicenseKit API → Xcode backend → thank-you page
- [x] Inline errors verified for invalid email, non-business email, and team size
- [x] Prettier and astro check pass
- [ ] After deploy: verify production form posts to teams.rocketsim.app and events appear in Plausible