### PR TITLE
SEO: query-facing titles for top Search Console clusters

### DIFF
--- a/docs/src/collections/feature-page/accessibility.md
+++ b/docs/src/collections/feature-page/accessibility.md
@@ -1,6 +1,7 @@
 ---
 title: "Accessibility"
-description: "Test accessibility with environment overrides, VoiceOver Navigator, and dynamic text controls."
+meta_title: "iOS Simulator Accessibility Testing - RocketSim"
+description: "Test accessibility on the iOS Simulator with environment overrides, VoiceOver Navigator, and Dynamic Type controls."
 hero:
   title: "Accessibility"
   subtitle: "Verify accessibility faster with overlays, navigator controls, and environment testing"

--- a/docs/src/collections/feature-page/networking.md
+++ b/docs/src/collections/feature-page/networking.md
@@ -1,6 +1,7 @@
 ---
 title: "Networking"
-description: "Monitor URLSession requests without proxy certificates, export AI-ready debugging prompts, control network speed, and simulate airplane mode."
+meta_title: "iOS Simulator Network Debugging & Speed Control - RocketSim"
+description: "Monitor URLSession requests without proxy certificates, throttle network speed, and simulate airplane mode on the iOS Simulator."
 hero:
   title: "Networking"
   subtitle: "Inspect requests, export AI-ready debugging context, and control Simulator network conditions"

--- a/docs/src/collections/feature-page/simulator-camera.md
+++ b/docs/src/collections/feature-page/simulator-camera.md
@@ -1,6 +1,7 @@
 ---
 title: "Simulator Camera"
-description: "Stream your macOS camera to test AVCapture APIs directly in the Simulator."
+meta_title: "Camera Support for the iOS Simulator - RocketSim"
+description: "Test your camera features in the iOS Simulator. Stream your Mac camera, a photo, or a video into any Simulator and skip the deploy-to-device loop."
 hero:
   title: "Simulator Camera"
   subtitle: "Test camera functionality without a physical device"

--- a/docs/src/content/docs/docs/features/accessibility/voiceover-navigator.md
+++ b/docs/src/content/docs/docs/features/accessibility/voiceover-navigator.md
@@ -1,6 +1,8 @@
 ---
-title: "VoiceOver Navigator"
+title: "Test VoiceOver on the iOS Simulator"
 description: "Visualize VoiceOver element order on the iOS Simulator with numbered overlays. Navigate elements with keyboard shortcuts and verify reading order without a device."
+sidebar:
+  label: "VoiceOver Navigator"
 ---
 
 ::::tip[Check accessibility faster]

--- a/docs/src/content/docs/docs/features/app-actions/location-simulation.md
+++ b/docs/src/content/docs/docs/features/app-actions/location-simulation.md
@@ -1,6 +1,8 @@
 ---
-title: "Location Simulation"
+title: "Location Simulation on the iOS Simulator and Devices"
 description: "Simulate GPS locations, custom coordinates, driving routes, and walking routes on the iOS Simulator or a physical iPhone or iPad with RocketSim."
+sidebar:
+  label: "Location Simulation"
 ---
 
 Testing location-aware apps should not require driving around with a MacBook. RocketSim lets you simulate GPS updates on the iOS Simulator and, starting with RocketSim 16.4 and Xcode 27, on a connected physical iPhone or iPad.

--- a/docs/src/content/docs/docs/features/capturing/simulator-camera-support.md
+++ b/docs/src/content/docs/docs/features/capturing/simulator-camera-support.md
@@ -1,11 +1,17 @@
 ---
-title: "iOS Simulator Camera Support"
-description: "Test camera functionality directly in the iOS Simulator without a physical device. Stream images or video to the Simulator camera via RocketSim Connect."
+title: "iOS Simulator Camera: Test Camera Flows Without a Device"
+description: "The iOS Simulator has no camera by default. RocketSim streams your Mac camera, images, or video into the Simulator so you can test camera flows."
+sidebar:
+  label: "Simulator Camera Support"
 ---
 
 Testing camera flows on the iOS Simulator usually ends with a fallback screen, since the Simulator does not expose a real camera like a physical device. That makes every QR scanner, document scanner, profile photo picker, or video capture flow slower to validate.
 
-RocketSim Camera Simulation lets you stream images or video into your running Simulator app through RocketSim Connect. You can keep your normal Simulator workflow and test camera-dependent UI without repeatedly deploying to an iPhone.
+## Does the iOS Simulator have a camera?
+
+No, Xcode's Simulator does not come with camera support: apps won't discover any capture device. RocketSim adds this missing camera by streaming your Mac's camera, a photo, or a video into your running Simulator app through RocketSim Connect. You can keep your normal Simulator workflow and test camera-dependent UI without repeatedly deploying to an iPhone.
+
+You can find an overview of what's possible on the [Simulator Camera feature page](/features/simulator-camera/).
 
 Check out these demos:
 

--- a/docs/src/content/docs/docs/features/networking/network-speed-control.mdx
+++ b/docs/src/content/docs/docs/features/networking/network-speed-control.mdx
@@ -1,8 +1,9 @@
 ---
-title: "Network Speed Control & Simulator Airplane Mode"
-description: "Throttle network speed on the iOS Simulator to test your app under 3G, Edge, or airplane mode conditions. Your Mac stays online while the Simulator is throttled."
+title: "Slow Network & Airplane Mode on the iOS Simulator"
+description: "Throttle the iOS Simulator to 3G or Edge, turn off its network completely, or enable airplane mode, all without a proxy and while your Mac stays online."
 sidebar:
   order: 1
+  label: "Network Speed Control"
 ---
 
 It's essential to test your app in bad networking conditions during app development. Historically, you've had to test this on an actual device using Airplane mode or turn off your Mac's WiFi. Both are not ideal and often slow you down during development.
@@ -22,7 +23,13 @@ To see this in action, you can watch our Network Monitoring demo on YouTube:
 
 RocketSim’s Network Speed Control allows you to test your app for poor connections within the Simulator. The best thing of all: your Mac’s internet connection stays working, so you can still access ChatGPT or Stack Overflow while developing your app.
 
-I encourage you to read my article [**Optimizing your app for Network Reachability**](https://www.avanderlee.com/swift/optimizing-network-reachability/) to prepare your app for bad networking conditions using RocketSim. For inspecting requests while testing, see [Network Traffic Monitoring](/docs/features/networking/network-traffic-monitoring).
+I encourage you to read my article [**Optimizing your app for Network Reachability**](https://www.avanderlee.com/swift/optimizing-network-reachability/) to prepare your app for bad networking conditions using RocketSim. For inspecting requests while testing, see [Network Traffic Monitoring](/docs/features/networking/network-traffic-monitoring). Network Speed Control is part of RocketSim's [networking tools for the iOS Simulator](/features/networking/).
+
+## Turn off the network for the Simulator only
+
+You don't have to turn off your Mac's WiFi to test your app offline. Select **Simulator Airplane Mode** to block all connections for your app, or use **100% packet loss** to simulate a connection that looks alive but never delivers data. Both profiles only affect the Simulator app you configured, so your Mac stays online.
+
+This is the quickest way to test offline mode, empty states, and error handling. You switch profiles from the side window while your app keeps running, so you can immediately see how your app responds.
 
 ## Control network conditions from the CLI
 


### PR DESCRIPTION
## Summary

Search Console (90 days ending Jul 23) shows several pages ranking on page 1 for high-intent queries while capturing few clicks, because titles are product-first instead of matching how developers search. This PR applies query-facing titles and meta descriptions in three batches:

- **Network cluster** (19k impressions, 1.5% CTR at pos ~5.5): retitle `network-speed-control` to "Slow Network & Airplane Mode on the iOS Simulator", add a "Turn off the network for the Simulator only" section covering the zero-click query variants (disable network, turn off wifi, offline mode), and give the `/features/networking/` page an SEO `meta_title`.
- **Camera cluster** (18.9k impressions, 3.5% CTR): retitle the docs page to "iOS Simulator Camera: Test Camera Flows Without a Device", add a direct-answer "Does the iOS Simulator have a camera?" section, sharpen the `/features/simulator-camera/` meta title/description, and cross-link the two pages.
- **Long tail**: add "iOS Simulator" phrasing to the location-simulation and voiceover-navigator titles, and an SEO meta_title for `/features/accessibility/`. Sidebar labels stay short via `sidebar.label`.

On-page H1s in docs change with the titles; feature-page heroes are unchanged (`meta_title` only affects the HTML title).

## Test plan

- [x] `npm run lint`, `format:check`, `typecheck`, `build`, `knip` all pass
- [x] Rendered `<title>` and meta description verified in `dist/` for all 7 pages
- [ ] After merge: re-check GSC cluster CTR in 4 weeks against baselines