### PR TITLE
Fix latest blog article ordering

### DIFF
--- a/docs/src/pages/blog/index.astro
+++ b/docs/src/pages/blog/index.astro
@@ -61,7 +61,8 @@ const items = posts
     slug: post.id,
     title: post.data.title,
     description: post.data.description,
-    date: post.data.modifiedTime ?? post.data.publishedTime,
+    date: post.data.publishedTime,
+    modifiedTime: post.data.modifiedTime ?? post.data.publishedTime,
     image: post.data.image ?? firstBodyImage(post.id, post.body ?? ""),
     imageAlt: post.data.imageAlt ?? post.data.title,
   }))
@@ -98,7 +99,7 @@ const structuredData = {
       name: post.title,
       description: post.description,
       url: `${base_url}/blog/${post.slug}`,
-      dateModified: post.date.toISOString(),
+      dateModified: post.modifiedTime.toISOString(),
     })),
   },
 };


### PR DESCRIPTION
## Summary
- sort the blog overview by publication date so updated older posts cannot replace the latest article
- continue using modification dates for structured-data freshness
- display each article's original publication date on the featured card and grid

## Test plan
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck` (0 errors; existing hints remain)
- [x] `npm run build`
- [x] `npm test`
- [x] Verify the benchmark article is featured as Latest on localhost