### PR TITLE
Add a manager approval guide

### DIFF
--- a/docs/src/content/docs/docs/support/faq.md
+++ b/docs/src/content/docs/docs/support/faq.md
@@ -3,6 +3,10 @@ title: "FAQ"
 description: "Frequently asked questions about RocketSim — licensing, App Store Connect issues, transparent captures, network speed control troubleshooting, and more."
 ---
 
+## How can I get my manager to approve RocketSim?
+
+Use the [RocketSim manager approval guide](/docs/support/how-to-get-rocketsim-approved-at-work/) for a copyable request, a simple payback summary, and answers to common procurement questions.
+
 ## Do you offer out-of-the App Store distribution?
 
 Yes, we do. Get in touch via [support@rocketsim.app](mailto:support@rocketsim.app)
@@ -13,7 +17,7 @@ Yes, you can consider buying [Team Licenses](https://www.rocketsim.app/for-teams
 
 ## I can’t reimburse App Store subscriptions, is there an alternative?
 
-Yes, we offer [Team Licenses](https://www.rocketsim.app/for-teams/).
+Yes, we offer [Team Licenses](https://www.rocketsim.app/for-teams/). The [manager approval guide](/docs/support/how-to-get-rocketsim-approved-at-work/) gives you a copyable request for centralized billing.
 
 ## Do you provide the option for commercial or team licenses?
 

--- a/docs/src/content/docs/docs/support/how-to-get-rocketsim-approved-at-work.md
+++ b/docs/src/content/docs/docs/support/how-to-get-rocketsim-approved-at-work.md
@@ -1,0 +1,99 @@
+---
+title: "How to Get RocketSim Approved at Work"
+description: "Copy a manager-ready RocketSim license request and find clear answers about productivity, payback, privacy, and team rollout."
+sidebar:
+  order: 1
+  label: "Manager Approval"
+---
+
+You already know where RocketSim saves you time. Your manager mainly needs to understand what it improves, whether other teams trust it, and how quickly the license pays for itself.
+
+The message below covers those points without requiring you to build a business case yourself. You can copy and send it as-is.
+
+:::tip[Copy and send]
+Use the copy button in the top-right corner of the message. The answers further down help if your manager has follow-up questions.
+:::
+
+## Copy the request
+
+```text
+Subject: RocketSim license request
+
+Hi,
+
+I'd like approval to continue using RocketSim for our iOS development work.
+
+RocketSim runs locally as a sandboxed Mac app with more than 30 features that
+make developing apps in the Simulator and on physical devices more efficient.
+It reduces context switching and repetitive work around testing, debugging,
+captures, accessibility, networking, and AI-assisted development.
+
+More than 250 teams use RocketSim, including Meta, Strava, and Google.
+Developers report becoming up to 2× faster after adopting it.
+
+A RocketSim Teams license costs €10 per seat per month, billed annually. That
+is roughly the cost of one or two developer hours per year, so saving about ten
+minutes per month already covers the license.
+
+RocketSim works alongside Xcode, requires little rollout effort, and includes
+centralized billing and license management for teams.
+
+I'd like approval to continue with RocketSim after the trial.
+
+Product overview: https://www.rocketsim.app/for-teams/
+```
+
+## Why it pays back quickly
+
+A Teams seat costs **€120 per year**. For most development teams, that is roughly the cost of one or two developer hours.
+
+RocketSim only needs to save about ten minutes per developer each month to cover the license. Developers report becoming **up to 2× faster**, which gives the team significantly more upside than the minimum payback.
+
+## Why teams choose RocketSim
+
+### More than one workflow
+
+RocketSim adds over 30 improvements across Simulator and physical-device development. You can use it for captures, network debugging, app actions, accessibility checks, design comparison, camera testing, build insights, and [agentic development](/docs/features/agentic-development/).
+
+This breadth matters when you build a business case. The license does not depend on a single feature or one project phase.
+
+### Adoption and productivity
+
+More than **250 teams** use RocketSim, including Meta, Strava, and Google.
+
+Developers report becoming **up to 2× faster** with RocketSim. For AI-assisted workflows, our published benchmark measured [over 99% less command output, about a 95% lower context estimate, and about 24% less command time](/blog/testing-ai-agents-ios-simulator/).
+
+### Local by default
+
+RocketSim is a sandboxed Mac app. [RocketSim Connect communication stays local on your Mac](/docs/getting-started/setting-up-rocketsim-connect/#privacy), and its recommended setup only loads into debug-launched Simulator apps.
+
+Teams can use centralized Build Insights and license management. Enterprise customers can disable Build Insights syncing when project, scheme, and build metadata must remain local.
+
+## Answer common objections
+
+### We already have development tools
+
+RocketSim works alongside Xcode instead of replacing it. It brings repeated Simulator workflows into one app, reducing the scripts, manual steps, and context switching your team would otherwise maintain itself.
+
+### Rollout will take too much time
+
+Developers install RocketSim as a regular Mac app. Teams use one shared license key, while most features work without changing the Xcode project. Features that use RocketSim Connect rely on a debug-only LLDB setup.
+
+### We need a security review
+
+Share the [RocketSim privacy policy](https://www.rocketsim.app/privacy/) and [terms and conditions](https://www.rocketsim.app/terms/) with your security, legal, or procurement team. Contact [RocketSim support](mailto:support@rocketsim.app) if they need additional product details.
+
+### We cannot reimburse App Store subscriptions
+
+[RocketSim Teams](https://www.rocketsim.app/for-teams/?utm_source=docs&utm_medium=referral&utm_content=manager_approval_docs) provides commercial licensing, centralized billing, and license management outside the Mac App Store. Enterprise plans add SAML SSO, custom distribution, and rollout support.
+
+### We need proof before purchasing
+
+Use the 14-day Teams trial to test the exact workflows you want to include in your request. No credit card is required, and you can invite the intended number of developers before measuring the result.
+
+## Choose the next step
+
+- [Compare RocketSim plans](https://www.rocketsim.app/pricing/?utm_source=docs&utm_medium=referral&utm_content=manager_approval_docs)
+- [Start a 14-day Teams trial](https://teams.rocketsim.app/signup/trial?utm_source=docs&utm_medium=referral&utm_content=manager_approval_docs)
+- [See how large teams use RocketSim](/docs/getting-started/how-large-teams-use-rocketsim/)
+- [Contact sales for 20+ seats](mailto:ralphduin@rocketsim.app)

--- a/docs/src/content/sections/statistics.md
+++ b/docs/src/content/sections/statistics.md
@@ -9,8 +9,8 @@ list:
     title: "30+"
     description: "RocketSim adds 30+ new features to Xcode's Simulator"
   - enable: true
-    title: "200+"
-    description: "Join **200+ teams** that already signed up for RocketSim for Teams"
+    title: "250+"
+    description: "Join **250+ teams** that already signed up for RocketSim for Teams"
   - enable: true
     title: "80.000+"
     description: "80k+ developers used RocketSim last year. Only 4% churned." # TODO: add one more fact

--- a/docs/src/pages/for-teams.astro
+++ b/docs/src/pages/for-teams.astro
@@ -180,7 +180,10 @@ const structuredData = {
             <h3 class="h6 mb-2 text-white">Need to justify another tool?</h3>
             <p class="text-text">
               One or two hours saved per developer each month can cover the seat
-              cost while giving managers better decisions.
+              cost while giving managers better decisions. Use our <a
+                href="/docs/support/how-to-get-rocketsim-approved-at-work/"
+                class="text-primary underline">manager approval guide</a
+              > to build a request with your own trial results.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add a copy-ready manager approval request with clear payback, trust, privacy, and rollout answers
- surface the guide from Support FAQ and the manager-focused Teams page
- align the public Teams adoption count at 250+

## Test plan
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck` (0 errors; existing hints remain)
- [x] `npm run build`
- [x] `npm test`
- [x] Review the copy controls, sidebar placement, and complete page on localhost

## Known existing check
- `npm run knip` still reports the existing unused `eslint-plugin-astro` dev dependency.