### PR TITLE
Improve the Teams conversion story

### DIFF
--- a/docs/src/components/TeamsTrialForm.astro
+++ b/docs/src/components/TeamsTrialForm.astro
@@ -116,6 +116,15 @@ const trialAction = `${teamsBaseUrl}/api/signup/trial?utm_source=website&utm_med
     text-align: center;
   }
 
+  .trial-form__proof {
+    margin: 1rem 0 0;
+
+    font-size: 0.8125rem;
+    color: var(--text-color-light);
+    line-height: 1.5;
+    text-align: center;
+  }
+
   .trial-form__pricing {
     display: block;
     margin-top: 1rem;
@@ -218,9 +227,12 @@ const trialAction = `${teamsBaseUrl}/api/signup/trial?utm_source=website&utm_med
       Start free Teams trial
     </button>
     <p class="trial-form__trust">
-      One shared license key. Essential setup and expiry emails are included.
+      €10 per seat/month, billed annually. One shared license key.
     </p>
   </form>
+  <p class="trial-form__proof">
+    Trusted by 250+ teams, including Meta, Strava, and Google.
+  </p>
   <a
     class="trial-form__pricing plausible-event-name=CTA:+Team+Page+-+See+Pricing plausible-event-surface=for-teams plausible-event-placement=for-teams-hero plausible-event-format=text-link plausible-event-source=website"
     href="/pricing/#plan-teams"

--- a/docs/src/content/team-insights/-index.md
+++ b/docs/src/content/team-insights/-index.md
@@ -1,6 +1,6 @@
 ---
-title: "RocketSim for Teams - Build Apps Faster with Insights"
-meta_title: "RocketSim for Teams - Build Apps Faster with Insights"
-description: "Give your whole iOS team shared build insights, machine benchmarks, and simulator tools — all under one license key. See how RocketSim scales across your organization."
+title: "RocketSim for Teams: Faster iOS Development and Build Insights"
+meta_title: "RocketSim for Teams: Faster iOS Development and Build Insights"
+description: "Give your iOS team over 30 faster Simulator and physical-device workflows, shared local-build insights, and one license key with RocketSim for Teams."
 draft: false
 ---

--- a/docs/src/old/components/Insights.astro
+++ b/docs/src/old/components/Insights.astro
@@ -29,7 +29,7 @@ import featureImage from "../../assets/features/build-insights.png";
   <div class="header-wrapper" data-aos="fade-in">
     <SectionHeader
       title="RocketSim for Teams"
-      subtitle="Increase the productivity of your whole team"
+      subtitle="Move faster every day and make build decisions with shared data"
     />
   </div>
   <div class="feature-wrapper">
@@ -46,10 +46,9 @@ import featureImage from "../../assets/features/build-insights.png";
         },
       }}
     >
-      Unlike Xcode, RocketSim will cache all your builds for months to follow.
-      You'll be able to compare build times and <strong
-        >get notified when compilation times increase.</strong
-      >
+      RocketSim tracks local clean and incremental build durations over time.
+      Compare results by scheme, Xcode version, macOS version, SDK, and hardware
+      without adding a build phase or maintaining an internal dashboard.
     </Feature>
   </div>
 </section>

--- a/docs/src/old/components/InsightsActionable.astro
+++ b/docs/src/old/components/InsightsActionable.astro
@@ -87,8 +87,8 @@ import gaugeAlertIcon from "../../assets/gauge-alert.svg";
         <article data-aos="fade-left" data-aos-delay="300">
           <Image src={gaugeIcon} alt="Speedometer icon" height="20" />
           <p>
-            Save up to 2 hours per month by upgrading older team MacBooks to an
-            M4 Max.
+            Compare older team MacBooks against newer hardware before approving
+            an upgrade.
           </p>
         </article>
       </li>
@@ -100,8 +100,8 @@ import gaugeAlertIcon from "../../assets/gauge-alert.svg";
             height="20"
           />
           <p>
-            Antoine is the only one building with Xcode 26.4, which can lead to
-            different build results.
+            Spot when one developer uses a different Xcode version that can
+            produce different build results.
           </p>
         </article>
       </li>
@@ -109,8 +109,8 @@ import gaugeAlertIcon from "../../assets/gauge-alert.svg";
         <article data-aos="fade-left" data-aos-delay="900">
           <Image src={gaugeIcon} alt="Speedometer icon" height="20" />
           <p>
-            Xcode 26.5 is your fastest version so far. Consider upgrading your
-            whole team.
+            Identify the fastest Xcode version for your project before rolling
+            it out to the whole team.
           </p>
         </article>
       </li>

--- a/docs/src/pages/for-teams.astro
+++ b/docs/src/pages/for-teams.astro
@@ -9,17 +9,20 @@ import Insights from "../old/components/Insights.astro";
 import InsightsBreakdown from "../old/components/InsightsBreakdown.astro";
 import InsightsActionable from "../old/components/InsightsActionable.astro";
 import OnlineTeamManager from "../old/components/OnlineTeamManager.astro";
-import AppStore from "../old/components/AppStore.astro";
 import TeamTestimonial from "../old/components/TeamTestimonial.astro";
-import CallToAction from "@/partials/CallToAction.astro";
 import TrustedBrands from "@/partials/TrustedBrands.astro";
 
 const pageIndex = await getEntry("team-insights", "-index");
 if (!pageIndex) return null;
 const { title, meta_title, description } = pageIndex.data;
 const {
-  site: { base_url },
+  site: { base_url, teams_base_url },
 } = config;
+const teamsUrl =
+  import.meta.env.MODE === "production"
+    ? teams_base_url
+    : "http://localhost:5173";
+const bottomTrialUrl = `${teamsUrl}/signup/trial?utm_source=website&utm_medium=website&utm_content=for_teams_bottom`;
 
 // Build SEO object
 const seo = {
@@ -41,8 +44,9 @@ const structuredData = {
 
 <Base seo={seo} structuredData={structuredData}>
   <Header title="Turn local Xcode builds into decisions backed by data">
-    Compare build duration by machine, Xcode version, project, and scheme —
-    without adding build phases, scripts, or dashboards to maintain.
+    Give every developer over 30 faster Simulator and physical-device workflows,
+    while shared local-build insights compare machines, Xcode versions,
+    projects, and schemes.
     <TeamsTrialForm slot="aside" />
   </Header>
   <TrustedBrands />
@@ -77,12 +81,21 @@ const structuredData = {
       find out{" "}
       <strong>which machine setup performs best</strong> for your Xcode project.
     </p>
+    <p class="mt-4 text-sm text-text">
+      Representative example: your dashboard uses your team's actual local build
+      data.
+    </p>
   </InsightsBreakdown>
   <InsightsBreakdown
-    title="Does Xcode 26.5 improve our project's build times?"
+    title="Does Xcode 27 improve our project's build times?"
     chart={{
       title: "Build Duration by Xcode Version",
       data: [
+        {
+          title: "Xcode 27",
+          value: 12.5,
+          width: 0.63,
+        },
         {
           title: "Xcode 26.5",
           value: 13.5,
@@ -92,11 +105,6 @@ const structuredData = {
           title: "Xcode 26.4",
           value: 15,
           width: 0.76,
-        },
-        {
-          title: "Xcode 26.3",
-          value: 15.3,
-          width: 0.78,
         },
       ],
     }}
@@ -108,6 +116,10 @@ const structuredData = {
       > build durations to tell you <strong
         >how much an Xcode version improves build times</strong
       > for your Xcode project.
+    </p>
+    <p class="mt-4 text-sm text-text">
+      Representative example: your dashboard uses your team's actual local build
+      data.
     </p>
   </InsightsBreakdown>
   <InsightsActionable />
@@ -148,20 +160,7 @@ const structuredData = {
             </p>
           </div>
         </div>
-        <blockquote
-          class="mt-12 p-8 rounded-2xl bg-primary/10 border border-primary/30"
-        >
-          <p class="text-text-dark text-lg">
-            "RocketSim Team Insights finally gives us visibility into our build
-            times beyond just gut feeling. We can actually measure the impact of
-            adding SDKs or improving configurations, seeing results reflected in
-            incremental and clean builds."
-          </p>
-          <footer class="text-text mt-4">
-            - Max Godfrey, iOS Developer at Tilt
-          </footer>
-        </blockquote>
-        <div class="mt-12 grid md:grid-cols-3 gap-6">
+        <div class="mt-12 grid md:grid-cols-2 gap-8">
           <div>
             <h3 class="h6 mb-2 text-white">Already track builds?</h3>
             <p class="text-text">
@@ -179,11 +178,25 @@ const structuredData = {
           <div>
             <h3 class="h6 mb-2 text-white">Need to justify another tool?</h3>
             <p class="text-text">
-              One or two hours saved per developer each month can cover the seat
-              cost while giving managers better decisions. Use our <a
+              Saving about ten minutes per developer each month can cover the
+              seat cost. Use our <a
                 href="/docs/support/how-to-get-rocketsim-approved-at-work/"
                 class="text-primary underline">manager approval guide</a
-              > to build a request with your own trial results.
+              > for a copy-ready request and payback summary.
+            </p>
+          </div>
+          <div>
+            <h3 class="h6 mb-2 text-white">
+              Need security or procurement details?
+            </h3>
+            <p class="text-text">
+              RocketSim runs locally as a sandboxed Mac app. Review our <a
+                href="/privacy/"
+                class="text-primary underline">privacy policy</a
+              > or <a
+                href="mailto:ralphduin@rocketsim.app"
+                class="text-primary underline">contact sales</a
+              > for 20+ seats, SAML SSO, custom distribution, and rollout support.
             </p>
           </div>
         </div>
@@ -198,6 +211,50 @@ const structuredData = {
       </div>
     </div>
   </section>
-  <CallToAction />
-  <AppStore />
+  <section class="section-sm pt-20 lg:pt-24">
+    <div class="container">
+      <div
+        class="bg-[#1d1d1f] rounded-3xl px-8 py-10 sm:p-12 lg:px-14 lg:py-12"
+      >
+        <div
+          class="grid items-center gap-8 lg:grid-cols-[minmax(0,1fr)_auto] lg:gap-14"
+        >
+          <div class="max-w-2xl">
+            <p class="text-sm font-semibold tracking-wide text-primary">
+              Trusted by 250+ teams
+            </p>
+            <h2
+              class="mt-3 text-3xl font-semibold leading-tight tracking-tight text-white text-balance sm:text-4xl"
+            >
+              Prove RocketSim's value in 14 days
+            </h2>
+            <p class="mt-4 max-w-xl text-base leading-relaxed text-text">
+              Invite your iOS developers, test the workflows they repeat every
+              week, and continue only when RocketSim earns its place.
+            </p>
+          </div>
+          <div
+            class="flex flex-col items-stretch gap-4 lg:min-w-[17rem] lg:items-center"
+          >
+            <a
+              href={bottomTrialUrl}
+              class="btn btn-primary text-center plausible-event-name=CTA:+Team+Page+-+Start+Trial"
+            >
+              Start free Teams trial
+            </a>
+            <a
+              href="/docs/support/how-to-get-rocketsim-approved-at-work/"
+              class="text-center text-sm font-semibold text-text-light underline decoration-white/30 underline-offset-4 transition-colors hover:text-primary"
+            >
+              Need approval? Copy the request &rarr;
+            </a>
+            <p class="text-center text-xs leading-relaxed text-text">
+              €10 per seat/month, billed annually<br />
+              No credit card required
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
 </Base>

--- a/docs/tests/build-output.test.js
+++ b/docs/tests/build-output.test.js
@@ -64,6 +64,38 @@ test("homepage videos stay deferred", () => {
   assert.deepEqual(eager, [], "every homepage video must keep preload=none");
 });
 
+test("Teams page preserves its conversion funnel contract", () => {
+  const html = readDist("for-teams/index.html");
+
+  assert.match(html, /data-teams-trial-form/);
+  assert.match(html, /utm_content=for_teams_hero_form/);
+  assert.match(html, /utm_content=for_teams_proof/);
+  assert.match(html, /utm_content=for_teams_bottom/);
+  assert.match(html, /CTA:\+Team\+Page\+-\+Proof\+Start\+Trial/);
+  assert.match(html, /CTA:\+Team\+Page\+-\+Start\+Trial/);
+  assert.match(
+    html,
+    /\/docs\/support\/how-to-get-rocketsim-approved-at-work\//,
+  );
+  assert.match(html, /€10 per seat\/month, billed annually/);
+});
+
+test("Teams page keeps its SEO metadata and legacy redirect", () => {
+  const html = readDist("for-teams/index.html");
+  assert.match(
+    html,
+    /RocketSim for Teams: Faster iOS Development and Build Insights/,
+  );
+  assert.match(
+    html,
+    /Give your iOS team over 30 faster Simulator and physical-device workflows/,
+  );
+  assert.match(html, /https:\/\/www\.rocketsim\.app\/for-teams/);
+
+  const redirect = readDist("team-insights/index.html");
+  assert.match(redirect, /\/for-teams/);
+});
+
 test("camera doc emits FAQPage structured data", () => {
   const html = readDist(
     "docs/features/capturing/simulator-camera-support/index.html",


### PR DESCRIPTION
## Summary
- broaden the Teams value proposition while preserving the existing inline trial funnel and historical analytics events
- strengthen pricing, adoption, ROI, security, and manager-approval proof throughout the page
- update representative benchmarks for Xcode 27 and replace the generic App Store footer with a focused Teams conversion close
- add build-output coverage for Teams SEO, attribution, trial form, approval links, and the legacy redirect

## Test plan
- [x] Review the complete page and responsive CTA locally
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck` (0 errors; existing hints remain)
- [x] `npm run build`
- [x] `npm test`