### PR TITLE
Polish Teams hero notifications on mobile

### DIFF
--- a/docs/src/old/components/Header.astro
+++ b/docs/src/old/components/Header.astro
@@ -83,6 +83,12 @@ const hasBelowCopy = Astro.slots.has("below-copy");
     }
   }
 
+  .hero__aside--after-copy {
+    @media (max-width: 799px) {
+      margin-top: 1.5rem;
+    }
+  }
+
   .logo-image {
     width: 4rem;
     height: auto;
@@ -121,7 +127,9 @@ const hasBelowCopy = Astro.slots.has("below-copy");
         )
       }
     </div>
-    <div class="hero__aside">
+    <div
+      class:list={["hero__aside", { "hero__aside--after-copy": hasBelowCopy }]}
+    >
       {
         hasAside ? (
           <slot name="aside" />

--- a/docs/src/old/components/InsightNotifications.astro
+++ b/docs/src/old/components/InsightNotifications.astro
@@ -13,7 +13,7 @@ const notifications = [
   {
     icon: gaugeAlertIcon,
     iconAlt: "Speedometer icon with exclamation mark",
-    text: "Antoine is the only one building with Xcode 26.5, which can lead to different build results.",
+    text: "Antoine is the only one on Xcode 26.5, risking different build results.",
   },
   {
     icon: gaugeIcon,
@@ -37,8 +37,8 @@ const notifications = [
   article {
     display: flex;
     align-items: flex-start;
-    gap: 1rem;
-    padding: 0.75rem 1.25rem;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
 
     color: #fff;
 
@@ -54,13 +54,22 @@ const notifications = [
       0px 0px 20px 3px rgba(7, 13, 79, 0.05),
       0px 0px 40px 20px rgba(7, 13, 79, 0.05),
       0 0 0 1px rgba(255, 255, 255, 0.06) inset;
+
+    @media (min-width: 600px) {
+      gap: 1rem;
+      padding-inline: 1.25rem;
+    }
   }
 
   /* The alert icon is wider than the plain gauge, so a fixed slot keeps every
      text block on the same leading edge. */
   .icon {
     display: flex;
-    flex: 0 0 2rem;
+    flex: 0 0 1.75rem;
+
+    @media (min-width: 600px) {
+      flex-basis: 2rem;
+    }
   }
 
   img {
@@ -69,10 +78,16 @@ const notifications = [
   }
 
   p {
-    margin: 0 2.5rem 0 0;
+    margin: 0;
 
-    font-size: 0.9375rem;
+    font-size: 0.875rem;
     text-wrap: balance;
+
+    @media (min-width: 600px) {
+      margin-right: 2.5rem;
+
+      font-size: 0.9375rem;
+    }
   }
 </style>
 


### PR DESCRIPTION
## Summary
- keep all three Teams hero notifications aligned at two lines down to a 320px viewport
- tighten mobile card spacing while preserving the existing desktop layout
- add separation between the notification stack and trial form on mobile

## Test plan
- [x] Verify 320px and 375px viewports have equal card heights, aligned text, and no horizontal overflow
- [x] Verify a 20px gap appears before the trial form
- [x] Run `npm run lint`
- [x] Run `npm run format:check`
- [x] Run `npm run typecheck`
- [x] Run `npm run build`
- [x] Run `npm run knip`