### PR TITLE
Sync RocketSim changelog

### DIFF
--- a/docs/src/data/changelog.md
+++ b/docs/src/data/changelog.md
@@ -2,8 +2,12 @@
 
 **Fixed:**
 
+- Fixed an empty black circle appearing on the side window's More button. (Thanks, H. v.d. Ploeg!)
 - Fixed App Store Connect rejecting App Previews exported with the "App Store Connect" option enabled. Those recordings were encoded as HEVC and could keep the recording's frame rate, while App Store Connect only accepts H.264 at up to 30 FPS. (Thanks, L. Mikusiak!)
 - Fixed deeply nested VoiceOver Overlay elements consuming too much horizontal space by capping their indentation.
+- Fixed RocketSim Connect's LLDB hook injecting into app-hosted test runs, which could pause snapshot tests at `UIApplicationMain` and surface duplicate Objective-C class warnings. Test hosts are now excluded by detecting loaded XCTest runtime modules. (Thanks, M. Caron!)
+- Fixed a race in RocketSim Connect's LLDB hook that could leave app launches paused at `UIApplicationMain` until manually continued, with Connect never attaching. The loader now captures the launch thread identity before resuming and safely recovers its own stops without ever touching user breakpoints or pauses. (Thanks, M. Heiberg and R. Mirzoyan!)
+- Fixed RocketSim Connect's LLDB hook suspending background threads while running to `UIApplicationMain`, which could permanently deadlock apps that wait on background work during startup (for example analytics SDK or telephony setup). The run-to-main plan now keeps all threads running.
 
 # 16.4.2
 


### PR DESCRIPTION
Updates the website changelog from the private RocketSim repository and records the latest public App Store release date.