### PR TITLE
Reduce docs agent context

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,224 +1,52 @@
 # Docs Agent Guidelines
 
-The marketing + documentation site for RocketSim, built with Astro/Starlight. For the domain terminology used across this site's content model (Post, Title, Page title, Featured post), see [CONTEXT.md](./CONTEXT.md).
+The RocketSim marketing and documentation site is built with Astro and Starlight. Run commands from this `docs/` directory.
+
+## Task routing
+
+- For site-specific terms such as Post, Title, Page title, and Featured post, read [CONTEXT.md](./CONTEXT.md).
+- Before creating or editing feature cards, feature pages, product documentation, or blog posts, read [CONTENT-AUTHORING.md](./CONTENT-AUTHORING.md). It contains the authoritative task-scoped guidance for frontmatter, assets, local serving, website voice, SEO, links, attribution, and install CTAs.
+- For the local MDX blog migration and its constraints, read [ADR 0001](./docs/adr/0001-blog-content-local-mdx.md).
 
 ## Commands
 
-- `npm run dev` - Start development server
+- `npm run dev` - Start the development server on port 4322
 - `npm run build` - Build for production
-- `npm run preview` - Preview production build
-- `npm run typecheck` - Type check the codebase
-- `npm run format:check` - Check code formatting
-- `npm run lint` - Lint the source code
-- `npm run knip` - Check for unused dependencies/exports
+- `npm run preview` - Preview the production build
+- `npm run typecheck` - Type-check Astro and TypeScript
+- `npm run format:check` - Check formatting
+- `npm run lint` - Lint source files
+- `npm run knip` - Check for unused dependencies, files, and exports
 
-## After Making Changes — Required Quality Gate
+## Required quality gate
 
-CI will **reject** the PR if any of the checks below fail. Always run every check from the `docs/` directory **before** committing and pushing:
+CI rejects the PR if any required check fails. Before committing and pushing, run all five commands from `docs/`:
 
 ```bash
-cd docs
-npm run lint          # ESLint
-npm run format:check  # Prettier (fix with: npx prettier --write .)
-npm run typecheck     # astro check (TypeScript)
-npm run build         # Production build
-npm run knip          # Unused files and dependencies
+npm run lint
+npm run format:check
+npm run typecheck
+npm run build
+npm run knip
 ```
 
-If `format:check` fails, run `npx prettier --write .` and commit the result.
+Every command must exit with code 0. If formatting fails, run `npx prettier --write .`, review the changes, and rerun the full gate.
 
-All five commands must exit with code 0 before you push.
+## Code conventions
 
-## Code Style Guidelines
-
-- Use TypeScript with strict type checking
-- Follow Astro recommended ESLint rules
-- Format code with Prettier (auto-configured for Astro files)
-- Use ES modules for imports/exports
-- Component files use `.astro` extension
-- Place new components in `/src/components`
-- Place new pages in `/src/pages`
-- Place static assets in `/public` directory
-- Content collections are in `/src/collections`
-- Switch statements must use closure brackets for each case:
-  ```typescript
-  switch (value) {
-    case "option1": {
-      return "result1";
-    }
-    case "option2": {
-      return "result2";
-    }
-    default: {
-      return "default";
-    }
-  }
-  ```
-
-## Content Authoring Guide
-
-### Features
-
-Every `.md` file inside `src/collections/feature` will be handled as a feature. Features with `showOnHomepage: true` are displayed on the landing page. Features can also be linked to a feature page via the `featurePage` field, grouping them into category pages at `/features/[slug]`.
-
-The Markdown files are separated into two sections:
-
-- Frontmatter YAML containing all data other than the content following a set data structure.
-- Content; allows writing markdown that gets converted into HTML when the project is built.
-
-The frontmatter schema is as follows:
+- Use strict TypeScript, ES modules, Astro's recommended ESLint rules, and the configured Prettier formatting.
+- Put Astro components in `src/components/`, pages in `src/pages/`, content collections in `src/collections/`, and static assets in `public/`.
+- Give every `switch` case, including `default`, its own braced block:
 
 ```typescript
-const alignment = z.enum(["left", "right", "full-width"]);
-const columnSpan = z.union([z.literal(6), z.literal(8), z.literal(12)]);
-
-type Alignment = "left" | "right" | "full-width";
-type ColumnSpan = 6 | 8 | 12;
-
-type Image = {
-  type: "image";
-  /** Path to asset INSIDE src folder */
-  path: string;
-  alt: string;
-  /** Optional caption to be shown underneath the asset (supports inline markdown) */
-  caption?: string;
-  /** Placement of the asset related to the content */
-  alignment: Alignment;
-  /** Width of the asset. Choose between 6 (50%), 8 (66.67%), or 12 (100%) */
-  columnSpan: ColumnSpan;
-};
-
-type Video = {
-  type: "video";
-  /** Path to asset in public folder */
-  path: string;
-  alt: string;
-  caption?: string;
-  alignment: Alignment;
-  columnSpan: ColumnSpan;
-};
-
-type Feature = {
-  name: string;
-  /** Whether this feature is shown on the homepage */
-  showOnHomepage: boolean; // defaults to false
-  tagLine?: string;
-  /** Path to related documentation */
-  docPath?: string;
-  /** WordPress blog post ID for linking to the related blog post */
-  blogId?: number;
-  /** Fragment identifier appended to the blog post URL */
-  blogFragment?: string;
-  /** YouTube video URL */
-  youtubeLink?: string; // must be a valid URL
-  /** Links this feature to a feature page category */
-  featurePage?:
-    | "accessibility"
-    | "app-actions"
-    | "build-insights"
-    | "design-comparison"
-    | "networking"
-    | "physical-devices"
-    | "screenshots-recordings"
-    | "simulator-camera"
-    | "status-bar"
-    | "user-defaults-editor";
-  /** Asset can be an image or a video */
-  asset: Image | Video;
-};
+switch (value) {
+  case "option1": {
+    return "result1";
+  }
+  default: {
+    return "default";
+  }
+}
 ```
 
-**NOTE:** Video assets need to be placed in the `public/` folder, while image assets need to be placed inside the `src/` folder. Assets in the `public/` folder won't be processed during the building of the project. Astro does not support video processing. We should take care of that ourselves (filesize, quality and resolution). For images this is done automatically. Feel free to use big image assets.
-
-An example feature:
-
-```md
----
-showOnHomepage: true
-name: "Quick Actions"
-featurePage: "app-actions"
-asset:
-  type: "video"
-  path: "/features/quick-actions.mp4"
-  alt: "RocketSim panel that shows configurable actions for locations, push notifications and deeplinks."
-  alignment: "right"
-  columnSpan: 6
----
-
-**Configurable actions** for Deeplinks (Universal Links), Push Notifications, locations, permissions, and quick state resets.
-
-- **Bundle Identifier based:** actions automatically show up for recent builds
-- Quickly test **Locations, Push Notifications, and Deeplinks**
-- Use **Reset Keychain** to clear stubborn authentication state faster
-```
-
-### Feature Pages
-
-Feature pages are category pages that group related features together. They live in `src/collections/feature-page/` and are rendered at `/features/[slug]`. Each feature page has a hero section and an optional bento grid layout.
-
-The available feature page slugs are: `accessibility`, `app-actions`, `build-insights`, `design-comparison`, `networking`, `physical-devices`, `screenshots-recordings`, `simulator-camera`, `status-bar`, `user-defaults-editor`.
-
-### Documentation
-
-Product documentation is powered by [Starlight](https://starlight.astro.build/) (an Astro integration) and lives in `src/content/docs/docs/`. Pages use `.md` or `.mdx` format with standard Starlight frontmatter (`title`, `description`).
-
-The sidebar structure is defined in `astro.config.ts` under `starlight.sidebar`. Some sections use `autogenerate` (auto-discovers pages in a directory), others list pages explicitly by `slug` or `link`.
-
-Current sidebar sections: Getting Started, Screenshots & Recordings, Simulator Camera, Status Bar, Design Comparison, App Actions, Networking, Build Insights, Accessibility, Agentic Development, User Defaults Editor, Settings, Support.
-
-Images for a doc page should be placed in a subfolder next to the `.md`/`.mdx` file and referenced with relative paths (e.g., `![Alt](./subfolder/image.png)`).
-
-When opening local docs pages in the browser:
-
-- First update against the latest default branch, for example `git fetch origin master` followed by `git merge origin/master` or another explicit branch update strategy.
-- Check any existing local dev server before using it. Confirm its process is serving from the current workspace checkout, not from another Cursor worktree or stale clone (for example, inspect `lsof -nP -iTCP:4322 -sTCP:LISTEN` and the process command).
-- If the server is from another checkout, stop it and restart `npm run dev -- --host 127.0.0.1` from the current `docs/` directory before opening the page.
-- Verify the served HTML contains a unique string from the change before reporting that the local page is updated.
-- Always use the configured trailing slash (for example, `http://localhost:4322/docs/features/networking/network-speed-control/`) to avoid stale optimized image URLs or route mismatches.
-
-Available shortcodes (auto-imported, no import statement needed):
-
-- `<Youtube id="..." title="..." />` — embeds a YouTube video
-- `<Accordion>` — collapsible content
-- `<Tweet />` — embedded tweet
-
-The documentation also generates `llms.txt` and `llms-full.txt` files via the `starlight-llms-txt` plugin for LLM consumption.
-
-### Blog
-
-The blog is powered by a headless WordPress instance. Blog posts are fetched at build time and statically rendered.
-
-Static, hand-coded blog articles live in `src/pages/blog/<slug>.astro` and use the `Base` layout with full `seo` and `structuredData` props. Use them for SEO-targeted articles where we want full control over markup, internal linking, and image handling.
-
-## Writing Blog Articles
-
-When writing or editing blog articles (both static `.astro` posts in `src/pages/blog/` and WordPress drafts):
-
-### Typographic conventions
-
-- **Use `→` (U+2192) for menu paths and step sequences**, never `>` or `&gt;`. For example: `Settings → Accessibility → VoiceOver`, not `Settings > Accessibility > VoiceOver`. This avoids ambiguity with HTML/MDX comparison operators and reads better.
-- Use em dashes (`—`, U+2014) for parenthetical asides, not double hyphens.
-- Use real Unicode arrows for keyboard shortcuts in body text: `↑`, `↓`, `←`, `→`, `⏎`, `Esc`, `⌘`. Wrap them in `<strong>` when listing shortcuts.
-
-### Voice and tone
-
-Articles are written in Antoine van der Lee's voice. Match the existing pattern in `src/pages/blog/15-voiceover-navigator-pro-xcode-simulator-recordings.astro` and `src/pages/blog/how-to-test-voiceover-on-the-xcode-simulator.astro`:
-
-- Direct, opinionated, practitioner voice — not academic.
-- Second person (`you`) for the reader; first person (`I`) for personal asides.
-- Short paragraphs (3–4 sentences max), variable sentence rhythm.
-- No filler openers like "In this section, we will…" or "Let's dive into…".
-- Standard closing pattern: short conclusion paragraph, then a CTA paragraph linking to the Mac App Store (with a `ct=` UTM parameter unique to the article), and end with `Thanks!`.
-
-### SEO requirements
-
-Every static blog article must:
-
-- Have a unique `slug`, `title`, `description`, `publishedTime`, and `modifiedTime`.
-- Keep the `<title>` tag (including ` - RocketSim` suffix) **≤ 60 characters**. If the headline you want to display is longer, declare a separate `pageTitle` constant for the visible `<h1>` and keep `title` short.
-- Keep the meta `description` **≤ 160 characters**, include the primary keyword once, and read as a self-contained value proposition.
-- Place the primary keyword in the URL slug, `<title>`, `<h1>`, the first paragraph, and at least one `<h2>`.
-- Pass `structuredData={{ type: "article", article: { … } }}` so the `Article` + `WebPage` + `BreadcrumbList` JSON-LD graph is emitted automatically.
-- Include at least two internal links (typically one to `/docs/features/<area>/<page>` and one to `/features/<area>`) and one authoritative external link (usually Apple developer documentation).
-- Provide descriptive, keyword-aware `alt` text on every image. Reuse images from `src/assets/blog/<release>/`, `src/assets/features/`, or `src/content/docs/...` instead of duplicating files.
-- Append a Mac App Store install link with a `ct=<article-slug>` UTM parameter in the CTA so installs from the article are attributable.
+For content-specific placement and asset rules, follow [CONTENT-AUTHORING.md](./CONTENT-AUTHORING.md).

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md
 
-All agent guidance for this project lives in [AGENTS.md](./AGENTS.md) — commands, the required quality gate, available MCP servers, code style, and the content authoring guide.
+Start with [AGENTS.md](./AGENTS.md) for commands, the required quality gate, code conventions, and task routing.
 
 For domain terminology (the site's content model), see [CONTEXT.md](./CONTEXT.md).
+
+For feature cards, feature pages, product documentation, and blog posts, follow the scoped [Content Authoring Guide](./CONTENT-AUTHORING.md).

--- a/docs/CONTENT-AUTHORING.md
+++ b/docs/CONTENT-AUTHORING.md
@@ -1,0 +1,171 @@
+# Content Authoring Guide
+
+Use this guide when creating or editing feature cards, feature pages, product documentation, or blog posts. For site-specific terms such as Post, Title, Page title, and Featured post, also read [CONTEXT.md](./CONTEXT.md).
+
+The schemas in `src/content.config.ts` and `src/types/pages.collection.ts` are authoritative. Update this guide when those schemas change.
+
+## Features
+
+Every Markdown file in `src/collections/feature/` is a feature card. Features with `showOnHomepage: true` appear on the landing page. The optional `featurePage` field groups a feature under `/features/[slug]`.
+
+Feature files contain YAML frontmatter followed by Markdown content. Their frontmatter has this shape:
+
+```typescript
+type Alignment = "left" | "right" | "full-width";
+type ColumnSpan = 6 | 8 | 12;
+
+type Image = {
+  type: "image";
+  /** Path to an image inside src/. */
+  path: string;
+  alt: string;
+  /** Supports inline Markdown. */
+  caption?: string;
+  alignment: Alignment;
+  columnSpan: ColumnSpan;
+};
+
+type Video = {
+  type: "video";
+  /** Path to a video inside public/. */
+  path: string;
+  alt: string;
+  caption?: string;
+  alignment: Alignment;
+  columnSpan: ColumnSpan;
+};
+
+type Feature = {
+  name: string;
+  showOnHomepage: boolean; // Defaults to false.
+  tagLine?: string;
+  docPath?: string;
+  /** Slug of a post in src/content/blog/. */
+  blogSlug?: string;
+  /** Fragment appended to the blog URL. */
+  blogFragment?: string;
+  youtubeLink?: string;
+  featurePage?:
+    | "accessibility"
+    | "agentic-development"
+    | "app-actions"
+    | "build-insights"
+    | "design-comparison"
+    | "networking"
+    | "physical-devices"
+    | "screenshots-recordings"
+    | "simulator-camera"
+    | "status-bar"
+    | "user-defaults-editor";
+  asset: Image | Video;
+};
+```
+
+Example:
+
+```md
+---
+showOnHomepage: true
+name: "Quick Actions"
+featurePage: "app-actions"
+asset:
+  type: "video"
+  path: "/features/quick-actions.mp4"
+  alt: "RocketSim panel showing configurable app actions."
+  alignment: "right"
+  columnSpan: 6
+---
+
+**Configurable actions** for deep links, push notifications, locations, permissions, and quick state resets.
+```
+
+Put videos in `public/` and optimize their file size, quality, and resolution before committing because Astro does not process videos. Put images in `src/`; Astro processes those automatically.
+
+## Feature pages
+
+Feature category pages live in `src/collections/feature-page/` and render at `/features/[slug]`. Each has a hero section and an optional bento grid. The current slugs are the `featurePage` values listed above.
+
+The authoritative feature-page schema is `featurePageSchema` in `src/types/pages.collection.ts`. Follow a neighboring feature-page file when authoring frontmatter and verify it against that schema.
+
+## Product documentation
+
+Starlight documentation lives in `src/content/docs/docs/` as `.md` or `.mdx` files. Use standard Starlight frontmatter, including `title` and `description`; repository-specific extensions are defined by the `docs` collection in `src/content.config.ts`.
+
+The sidebar is configured under `starlight.sidebar` in `astro.config.ts`. Some sections autogenerate from directories, while others list `slug` or `link` values explicitly. Check that configuration when adding, moving, or renaming a page.
+
+Place documentation images in a subfolder beside the page and use relative paths, for example `![Alt text](./image-folder/image.png)`.
+
+These components are auto-imported:
+
+- `<Youtube id="..." title="..." />`
+- `<Accordion>`
+- `<Tweet />`
+
+The `starlight-llms-txt` plugin also generates `llms.txt` and `llms-full.txt`.
+
+### Local serving safety
+
+When opening a local documentation page:
+
+1. Start from the latest default branch using an explicit update strategy.
+2. Before reusing port 4322, inspect its listener, for example with `lsof -nP -iTCP:4322 -sTCP:LISTEN`, and confirm the process serves the current checkout rather than another worktree or stale clone.
+3. If it serves another checkout, stop it and run `npm run dev -- --host 127.0.0.1` from the current `docs/` directory.
+4. Open the route with its configured trailing slash, for example `http://localhost:4322/docs/features/networking/network-speed-control/`.
+5. Verify the served HTML contains a unique string from the current change before reporting that the page is updated.
+
+## Blog posts
+
+Blog posts are local MDX content. Each post is a self-contained folder at `src/content/blog/<slug>/index.mdx`; the folder name is the URL slug. Treat published post folders as immutable snapshots: keep their images inside the post folder instead of referencing documentation or shared images that may later change.
+
+Blog frontmatter follows this schema:
+
+```typescript
+type BlogPost = {
+  /** SEO title used by the HTML title and overview card. */
+  title: string;
+  /** Visible h1 and structured-data headline; defaults to title. */
+  pageTitle?: string;
+  description: string;
+  publishedTime: Date | string;
+  /** Defaults to publishedTime. */
+  modifiedTime?: Date | string;
+  /** Local image processed by Astro and used for the hero and Open Graph. */
+  image?: ImageMetadata;
+  imageAlt?: string;
+  imageCaption?: string;
+};
+```
+
+Use `src/content.config.ts` as the authoritative schema and follow current posts for MDX structure. For architectural context, see [ADR 0001](./docs/adr/0001-blog-content-local-mdx.md).
+
+### Typography
+
+- Use `→` (U+2192) for menu paths and step sequences, never `>` or `&gt;`: `Settings → Accessibility → VoiceOver`.
+- Use em dashes (`—`, U+2014) for parenthetical asides, not double hyphens.
+- Use real Unicode keyboard symbols in body text: `↑`, `↓`, `←`, `→`, `⏎`, `Esc`, and `⌘`. Wrap them in `<strong>` when listing shortcuts.
+
+### Voice and tone
+
+Write in Antoine van der Lee's direct, opinionated practitioner voice. Use second person (`you`) for the reader and first person (`I`) for personal asides. Keep paragraphs short, vary sentence rhythm, and avoid filler openers such as "In this section, we will…" or "Let's dive into…".
+
+Match current posts such as:
+
+- `src/content/blog/15-voiceover-navigator-pro-xcode-simulator-recordings/index.mdx`
+- `src/content/blog/how-to-test-voiceover-on-the-xcode-simulator/index.mdx`
+
+Close with a short conclusion followed by a RocketSim install CTA and end with `Thanks!`.
+
+### SEO, attribution, and links
+
+Every blog post must:
+
+- Use a unique folder slug, `title`, `description`, and `publishedTime`; set `modifiedTime` when editing a published post.
+- Keep the HTML title, including the ` - RocketSim` suffix, at 60 characters or fewer. Use `pageTitle` for a longer visible heading.
+- Keep `description` at 160 characters or fewer, include the primary keyword once, and make it a self-contained value proposition.
+- Put the primary keyword in the folder slug, `title`, visible h1, first paragraph, and at least one h2.
+- Include at least two relevant internal links, typically one documentation page under `/docs/features/` and one feature page under `/features/`.
+- Include at least one authoritative external link, usually Apple developer documentation.
+- Give every image descriptive, keyword-aware alt text.
+- End with a Mac App Store install CTA whose URL contains a unique `ct=<article-slug>` campaign parameter so installs remain attributable. Preserve the existing `pt` and `mt` query parameters.
+
+The shared blog layout emits the Article, WebPage, and BreadcrumbList structured-data graph from the collection data. Verify the rendered graph instead of adding page-specific structured data.


### PR DESCRIPTION
## Summary
- reduce `docs/AGENTS.md` to commands, safety and quality gates, concise conventions, and task routing
- move feature/frontmatter schemas, content examples, local-serving safety, and blog voice/SEO/attribution requirements into `docs/CONTENT-AUTHORING.md`
- update `docs/CLAUDE.md` to route content work to the scoped guide
- align blog guidance with the current local MDX content model

## Context metrics
- before: 10,814 bytes / 224 lines
- after: 2,006 bytes / 52 lines
- reduction: 8,808 bytes (81.5%) / 172 lines (76.8%)

## Validation
- relative Markdown links validated
- `npx prettier --check AGENTS.md CONTENT-AUTHORING.md CLAUDE.md`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `npm run knip`