### PR TITLE
Document SSO authentication in Terms and Privacy Policy

### DIFF
--- a/docs/src/pages/privacy.astro
+++ b/docs/src/pages/privacy.astro
@@ -69,7 +69,8 @@ const seo = {
       <section>
         <p>
           <em
-            >This privacy statement was most recently revised on 18 June 2026</em
+            >This privacy statement was most recently revised on 4 September
+            2026</em
           >
         </p>
         <p>
@@ -255,6 +256,62 @@ const seo = {
           will be permanently deleted within 30 days.
         </p>
       </section>
+      <section aria-labelledby="sso-authentication">
+        <h3 id="sso-authentication" class="title--underline">
+          <em>Single Sign-On (SSO) authentication</em>
+        </h3>
+        <p>
+          <strong>Purpose:</strong> To allow users to authenticate through their organization's
+          identity provider using Single Sign-On (SSO).
+        </p>
+        <p><strong>Personal data:</strong></p>
+        <ul>
+          <li>Email address</li>
+          <li>Full name</li>
+          <li>Email verification status</li>
+          <li>Whether the user authenticated through SSO</li>
+          <li>
+            Authentication tokens required to establish, maintain, or terminate
+            the authenticated session
+          </li>
+        </ul>
+        <p>
+          This information is received from the user's identity provider or
+          generated as part of the authentication flow. RocketSim does not
+          create or store a password for users who authenticate through SSO. The
+          authentication flow requests the <code>openid</code>,
+          <code>profile</code>, and <code>email</code> scopes.
+        </p>
+        <p><strong>Temporary session data:</strong></p>
+        <p>
+          State, nonce, and a PKCE code verifier are temporarily processed to
+          complete the authentication flow securely. This data is deleted after
+          successful authentication or when the authentication attempt expires.
+        </p>
+        <p><strong>Cookies:</strong></p>
+        <p>
+          A temporary, secure, HTTP-only cookie named
+          <code>sso_session_code</code> is used to exchange the authentication session
+          for access and refresh tokens. It is cleared after the exchange or upon
+          expiration and is not used for advertising, analytics, or cross-site tracking.
+        </p>
+        <p><strong>Legal basis:</strong></p>
+        <ul>
+          <li>
+            Execution of an agreement with the data subject or our legitimate
+            interest in providing secure access to the services under the
+            agreement with the user's organization.
+          </li>
+        </ul>
+        <p>
+          <strong>Retention period:</strong><br />Account data is retained
+          during the subscription term and permanently deleted within 30 days
+          after termination of the subscription. Temporary session data and
+          cookies are deleted after use or upon expiration. Authentication
+          tokens expire or are revoked in accordance with the applicable session
+          settings.
+        </p>
+      </section>
       <section aria-labelledby="contact">
         <h3 id="contact"><em>Contact</em></h3>
         <p>
@@ -335,6 +392,10 @@ const seo = {
         <p>Third parties processing personal data on our behalf or yours:</p>
         <ul>
           <li>MailGun – to send emails</li>
+          <li>
+            Auth0 (by Okta) – to broker SSO authentication between RocketSim and
+            the customer's identity provider
+          </li>
         </ul>
         <p>
           RocketSim may provide your personal data to parties located outside

--- a/docs/src/pages/terms.astro
+++ b/docs/src/pages/terms.astro
@@ -490,6 +490,11 @@ const seo = {
               To access and use the Services, the Customer will be provided with
               an Account and asked to provide login information (a unique
               username and password) after conclusion of the Agreement.
+              Alternatively, where the Customer's organization has configured
+              Single Sign-On (SSO) for its email domain, Users may authenticate
+              through the Customer's identity provider, such as Okta, Microsoft
+              Entra ID, or Google Workspace. In that case, credentials are
+              managed by the Customer's identity provider and not by RocketSim.
             </li>
             <li>
               The Customer is obliged to use any Account made available by
@@ -500,6 +505,14 @@ const seo = {
               approval of the Customer. The Customer is obliged to notify
               RocketSim immediately if it suspects abuse of and/or unauthorized
               access to its Accounts.
+            </li>
+            <li>
+              When using SSO, authentication is governed by the policies and
+              security controls of the Customer's identity provider. RocketSim
+              is not responsible for credential management, access policies, or
+              authentication failures handled by that identity provider. SSO
+              access requires a valid license and an SSO domain mapping
+              configured for the Customer's organization.
             </li>
           </ol>
         </li>


### PR DESCRIPTION
## Summary

- Documents organization-managed SSO authentication in the Terms of Service.
- Explains the identity and authentication data processed during SSO in the Privacy Policy.
- Documents temporary OAuth/OIDC session data, the `sso_session_code` cookie, retention, and Auth0's role as authentication broker.
- Updates the Privacy Policy revision date.

## Context

This replaces #952 by applying its approved intent to the current legal pages. The wording was refreshed to avoid coupling the policy to volatile token lifetimes or storage details, to cover the applicable GDPR basis when the subscribing customer is the user's organization, and to use the current Microsoft Entra ID product name.

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run typecheck` (passes with four existing hints)
- `npm run build`
- `npm test` (7 tests passed)

Co-authored with the original contributors from #952.